### PR TITLE
🐛 N°5367 - Fix non-string values (boolean, null) converted into empty string

### DIFF
--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -686,7 +686,11 @@
 		$aPreparedData = [];
 		foreach ($aInputData as $sKey => $value) {
 			$sPreparedKey = MetaModel::ApplyParams($sKey, $aContextArgs);
-			$preparedValue = is_array($value) ? $this->ApplyParamsToArray($aContextArgs, $value) : MetaModel::ApplyParams($value, $aContextArgs);
+			
+			// N°5367 - Fix non-string values (boolean, null) converted into empty string
+			// Some APIs explicitly require booleans such as 'false'; or null values.
+			// Do not convert those into a string by calling MetaModel::ApplyParams().
+			$preparedValue = is_array($value) ? $this->ApplyParamsToArray($aContextArgs, $value) : (is_string($value) ? MetaModel::ApplyParams($value, $aContextArgs) : $value);
 
 			$aPreparedData[$sPreparedKey] = $preparedValue;
 		}


### PR DESCRIPTION
While experimenting with a Discord implementation, I noticed that booleans (such as `false`) and 
`null` values get converted into an empty string.

This results in failing HTTP requests.
