### PR TITLE
Allow all HTTP methods

### DIFF
--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -410,8 +410,7 @@
 		// Prepare cURL options
 		$aCURLOptions = array(
 			CURLOPT_RETURNTRANSFER => true,
-			// Note: Even though we might have something else than "get" and "post" in the $sMethod, for now we only set it to these 2 values in the cURL options. It should be reworked / fixed.
-			CURLOPT_POST => ($sMethod === 'post'),
+			CURLOPT_CUSTOMREQUEST => strtoupper($sMethod),
 			// Note: We pass headers as a cURL option to avoid  bug N°3267 in \utils::DoPostRequest()
 			CURLOPT_HTTPHEADER => $aHeaders,
 			CURLOPT_CONNECTTIMEOUT => $sConnectionTimeoutInSeconds,


### PR DESCRIPTION
The web requests were send as POST or GET for any other options