### PR TITLE
N°5796 - Fix typo in ActionWebhook::GetRemoteApplicationConnectionFromActionWebhok()

### DIFF
--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -338,7 +338,7 @@
 	 *
 	 * @return \RemoteApplicationConnection {@see static::GetRemoteApplicationConnection}
 	 */]]></comment>
-					<code><![CDATA[	static public function GetRemoteApplicationConnectionFromActionWebhok($oAction)
+					<code><![CDATA[	static public function GetRemoteApplicationConnectionFromActionWebhook($oAction)
 	{
 		return $oAction->GetRemoteApplicationConnection();
 	}


### PR DESCRIPTION
No impact in current module as the method is not used.