### PR TITLE
:bug: Validate the prepared JSON instead of the input JSON

### DIFF
--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -736,15 +736,16 @@
 					<code><![CDATA[
 protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 	{
-		$aInputAsArray = json_decode($sInputAsJson, true);
-		if (false === is_array($aInputAsArray)) {
+		$sPreparedDataAsJson = MetaModel::ApplyParams($sInputAsJson, $aContextArgs);
+		$aPreparedDataAsArray = json_decode($sPreparedDataAsJson, true);
+		if (false === is_array($aPreparedDataAsArray)) {
 			// LogChannels class and NOTIFICATIONS constant were introduced recently, we can't use it with a 2.7.0 compatibility
 			$sLogChannel = 'notifications';
 			$aLogContext = [
 				'action_class'        => get_class($this),
 				'action_id'           => $this->GetKey(),
 				'action_name'         => $this->Get('name'),
-				'payload'             => $sInputAsJson,
+				'payload'             => $sPreparedDataAsJson,
 				'json_last_error'     => json_last_error(),
 				'json_last_error_msg' => json_last_error_msg(),
 			];
@@ -752,9 +753,6 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 
 			throw new Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException('Wrong JSON format for input, see error log for more information.');
 		}
-
-		$aPreparedDataAsArray = $this->ApplyParamsToArray($aContextArgs, $aInputAsArray);
-		$sPreparedDataAsJson = json_encode($aPreparedDataAsArray);
 
 		return $sPreparedDataAsJson;
 	}

--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -728,8 +728,6 @@
 	 * @throw InvalidJsonValueException if payload has an invalid format
 	 *
 	 * @uses json_decode
-	 * @uses json_encode
-	 * @uses ApplyParamsToArray
 	 *
 	 * @since 1.1.2 N°5473 in case invalid JSON : replace Exception by WebhookInvalidJsonValueException, and more data logged (IssueLog)
 	 */]]></comment>

--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -735,8 +735,8 @@
 protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 	{
 		$sPreparedDataAsJson = MetaModel::ApplyParams($sInputAsJson, $aContextArgs);
-		$aPreparedDataAsArray = json_decode($sPreparedDataAsJson, true);
-		if (false === is_array($aPreparedDataAsArray)) {
+		json_decode($sPreparedDataAsJson, true);
+		if (json_last_error() !== JSON_ERROR_NONE) {
 			// LogChannels class and NOTIFICATIONS constant were introduced recently, we can't use it with a 2.7.0 compatibility
 			$sLogChannel = 'notifications';
 			$aLogContext = [


### PR DESCRIPTION
The current implementation doesn't support the following input JSON:
```
{ "some_integer": $this->some_integer$ }
```
While this can produce valid JSON after prepare:
```json
{ "some_integer": 123 }
```