### PR TITLE
N°5921 - Add support for token authentication via a new RemoteApplicationConnection

### DIFF
--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -62,7 +62,7 @@
 				<reconciliation>
 					<attributes>
 						<attribute id="name"/>
-						<attribute id="application"/>
+						<attribute id="remoteapplicationtype_id"/>
 						<attribute id="environment"/>
 					</attributes>
 				</reconciliation>
@@ -94,7 +94,23 @@
 					<ext_key_to_me>remoteapplicationconnection_id</ext_key_to_me>
 				</field>
 			</fields>
-			<methods/>
+			<methods>
+				<method id="PrepareHeaders">
+					<static>false</static>
+					<access>public</access>
+					<type>Overload-DBObject</type>
+					<comment><![CDATA[/**
+	 * Prepare connection specific headers (e.g. authentication)
+	 * @return string[]
+	 */]]></comment>
+					<code><![CDATA[	public function PrepareHeaders(array $aContextArgs, \EventNotification &$oLog)
+	{
+		return [];
+	}
+]]>
+					</code>
+				</method>
+			</methods>
 			<presentation>
 				<details>
 					<items>
@@ -175,7 +191,7 @@
 				<reconciliation>
 					<attributes>
 						<attribute id="name"/>
-						<attribute id="application"/>
+						<attribute id="remoteapplicationtype_id"/>
 						<attribute id="environment"/>
 					</attributes>
 				</reconciliation>
@@ -197,7 +213,32 @@
 					<is_null_allowed>false</is_null_allowed>
 		        </field>
 			</fields>
-			<methods/>
+			<methods>
+				<method id="PrepareHeaders">
+					<static>false</static>
+					<access>public</access>
+					<type>Overload-DBObject</type>
+					<comment><![CDATA[/**
+	 * Prepare connection specific headers (e.g. authentication)
+	 * @return string[]
+	 */]]></comment>
+					<code><![CDATA[	public function PrepareHeaders(array $aContextArgs, \EventNotification &$oLog)
+	{
+		$aHeaders = parent::PrepareHeaders($aContextArgs, $oLog);
+
+		// Prepare Basic Auth header
+		$sAuthUser = $this->Get('auth_user');
+		$sAuthPwd = $this->Get('auth_pwd');
+		$sEncryptedCredentials = base64_encode("$sAuthUser:$sAuthPwd");
+
+		$aHeaders[] = "Authorization: Basic $sEncryptedCredentials";
+
+		return $aHeaders;
+	}
+]]>
+					</code>
+				</method>
+			</methods>
 			<presentation>
 				<details>
 					<items>
@@ -232,6 +273,108 @@
 										</item>
 										<item id="auth_pwd">
 											<rank>20</rank>
+										</item>
+									</items>
+								</item>
+							</items>
+						</item>
+						<item id="actions_list">
+							<rank>100</rank>
+						</item>
+					</items>
+				</details>
+			</presentation>
+		</class>
+        <class id="RemoteiTopConnectionToken" _delta="define">
+			<parent>RemoteApplicationConnection</parent>
+			<properties>
+				<category>grant_by_profile,bizmodel,searchable</category>
+				<abstract>false</abstract>
+				<key_type>autoincrement</key_type>
+				<db_table>remoteitopconnectiontoken</db_table>
+				<db_key_field>id</db_key_field>
+				<db_final_class_field/>
+				<naming>
+					<attributes>
+						<attribute id="name"/>
+					</attributes>
+				</naming>
+				<display_template/>
+				<icon/>
+				<reconciliation>
+					<attributes>
+						<attribute id="name"/>
+						<attribute id="remoteapplicationtype_id"/>
+						<attribute id="environment"/>
+					</attributes>
+				</reconciliation>
+			</properties>
+			<fields>
+                <field id="version" xsi:type="AttributeString">
+					<sql>version</sql>
+					<default_value>1.3</default_value>
+					<is_null_allowed>false</is_null_allowed>
+		        </field>
+		        <field id="token" xsi:type="AttributeEncryptedString">
+					<sql>token</sql>
+					<default_value/>
+					<is_null_allowed>false</is_null_allowed>
+		        </field>
+			</fields>
+			<methods>
+				<method id="PrepareHeaders">
+					<static>false</static>
+					<access>public</access>
+					<type>Overload-DBObject</type>
+					<comment><![CDATA[/**
+	 * Prepare connection specific headers (e.g. authentication)
+	 * @return string[]
+	 */]]></comment>
+					<code><![CDATA[	public function PrepareHeaders(array $aContextArgs, \EventNotification &$oLog)
+	{
+		$aHeaders = parent::PrepareHeaders($aContextArgs, $oLog);
+
+		// Prepare Basic Auth header
+		$sToken = $this->Get('token');
+		$aHeaders[] = "Auth-Token: $sToken";
+
+		return $aHeaders;
+	}
+]]>
+					</code>
+				</method>
+			</methods>
+			<presentation>
+				<details>
+					<items>
+						<item id="col:col0">
+							<rank>10</rank>
+							<items>
+								<item id="fieldset:RemoteApplicationConnection:baseinfo">
+									<rank>10</rank>
+									<items>
+										<item id="name">
+											<rank>10</rank>
+										</item>
+										<item id="remoteapplicationtype_id">
+											<rank>20</rank>
+										</item>
+										<item id="environment">
+											<rank>30</rank>
+										</item>
+										<item id="url">
+											<rank>40</rank>
+										</item>
+										<item id="version">
+											<rank>50</rank>
+										</item>
+									</items>
+								</item>
+								<item id="fieldset:RemoteApplicationConnection:authinfo">
+									<rank>20</rank>
+									<items>
+										<item id="token">
+											<rank>10</rank>
 										</item>
 									</items>
 								</item>
@@ -553,6 +696,15 @@
 
 		if (count($aHeaders) === 0) {
 			$aHeaders[] = 'Content-type: application/json';
+		}
+
+		// Retrieve connection, to let it add some extra headers (e.g. authentication)
+		$oRemoteApplicationconnection = $this->GetRemoteApplicationConnection();
+		$aExtraHeaders = $oRemoteApplicationconnection->PrepareHeaders($aContextArgs, $oLog);
+
+		foreach($aExtraHeaders as $sExtraHeader)
+		{
+			$aHeaders[] = $sExtraHeader;
 		}
 
 		return $aHeaders;
@@ -968,34 +1120,6 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 	{
 		// Set default content-type
 		$this->Set("headers", "Content-type: application/x-www-form-urlencoded");
-	}
-]]>
-					</code>
-				</method>
-				<method id="PrepareHeaders">
-					<static>false</static>
-					<access>protected</access>
-					<type>Overload-DBObject</type>
-					<comment><![CDATA[/**
-	 * Add Authorization Basic header
-	 *
-	 * @inheritDoc
-	 */]]></comment>
-					<code><![CDATA[	protected function PrepareHeaders(array $aContextArgs, \EventNotification &$oLog)
-	{
-		$aHeaders = parent::PrepareHeaders($aContextArgs, $oLog);
-
-		// Retrieve connection
-		$oRemoteApplicationconnection = $this->GetRemoteApplicationConnection();
-
-		// Prepare Basic Auth header
-		$sAuthUser = MetaModel::ApplyParams($oRemoteApplicationconnection->Get('auth_user'), $aContextArgs);
-		$sAuthPwd = MetaModel::ApplyParams($oRemoteApplicationconnection->Get('auth_pwd'), $aContextArgs);
-		$sEncryptedCredentials = base64_encode("{$sAuthUser}:{$sAuthPwd}");
-
-		$aHeaders[] = "Authorization: Basic {$sEncryptedCredentials}";
-
-		return $aHeaders;
 	}
 ]]>
 					</code>

--- a/en.dict.combodo-webhook-integration.php
+++ b/en.dict.combodo-webhook-integration.php
@@ -106,6 +106,10 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Class:RemoteiTopConnection/Attribute:version' => 'API version',
 	'Class:RemoteiTopConnection/Attribute:version+' => 'Version of the API called (eg. 1.3)',
 
+	// RemoteiTopConnectionToken
+	'Class:RemoteiTopConnectionToken' => 'Remote iTop connection using a Token',
+	'Class:RemoteiTopConnectionToken/Attribute:token+' => 'Token',
+
 	// ActioniTopWebhook
 	'Class:ActioniTopWebhook' => 'iTop webhook call',
 	'Class:ActioniTopWebhook+' => 'Webhook call to a remote iTop application',

--- a/fr.dict.combodo-webhook-integration.php
+++ b/fr.dict.combodo-webhook-integration.php
@@ -39,6 +39,7 @@ Dict::Add('FR FR', 'French', 'Français', array(
 	'Class:RemoteApplicationConnection/Attribute:version+' => 'Version de l\'API utilisée sur l\'itop distant (ex : 1.3)',
 	'Class:RemoteApplicationConnection/Attribute:actions_list' => 'Appels webhook',
 	'Class:RemoteApplicationConnection/Attribute:actions_list+' => 'Appels utilisant cette URL de webhook',
+
 	// - Fieldsets
 	'RemoteApplicationConnection:baseinfo' => 'Informations générales',
 	'RemoteApplicationConnection:moreinfo' => 'Autres informations',
@@ -105,6 +106,11 @@ Dict::Add('FR FR', 'French', 'Français', array(
 	'Class:RemoteiTopConnection/Attribute:auth_pwd+' => 'Mot de passe de l\'utilisateur (sur l\'iTop distant) utilisé pour l\'authentification',
 	'Class:RemoteiTopConnection/Attribute:version' => 'Version de l\'API',
 	'Class:RemoteiTopConnection/Attribute:version+' => 'Version de l\'API utilisée sur l\'itop distant (ex : 1.3)',
+
+	// RemoteiTopConnectionToken
+	'Class:RemoteiTopConnectionToken' => 'Connexion iTop distant via un Jeton',
+	'Class:RemoteiTopConnectionToken/Attribute:token' => 'Jeton',
+	'Class:RemoteiTopConnectionToken/Attribute:token+' => 'Un jeton personnel d\'identification',
 
 	// ActioniTopWebhook
 	'Class:ActioniTopWebhook' => 'Appel de webhook iTop',

--- a/test/ActionWebhook/ActionWebhookTest.php
+++ b/test/ActionWebhook/ActionWebhookTest.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * Copyright (C) 2023 Combodo SARL
+ * This file is part of iTop.
+ * iTop is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * iTop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ */
+
+namespace Combodo\iTop\Core\Test;
+
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use RemoteiTopConnection;
+use RemoteiTopConnectionToken;
+use RemoteApplicationType;
+use ActioniTopWebhook;
+use EventNotification;
+use MetaModel;
+
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ * @backupGlobals disabled
+ */
+class ActionWebhookTest extends ItopDataTestCase
+{
+	protected function setUp(): void {
+		parent::setUp();
+	}
+
+	public function testPrepareHeader()
+	{
+		$oRemoteApplicationType = new RemoteApplicationType();
+		$oRemoteApplicationType->Set('name', 'iTop');
+		$oRemoteApplicationType->DBWrite();
+
+		// iTop connexion via username / password
+		$oRemoteApplication = new RemoteiTopConnection();
+		$oRemoteApplication->Set('name', 'Test iTop');
+		$oRemoteApplication->Set('remoteapplicationtype_id', $oRemoteApplicationType->GetKey());
+		$oRemoteApplication->Set('url', 'https://www.combodo.com');
+		$oRemoteApplication->Set('auth_user', 'administrator');
+		$oRemoteApplication->Set('auth_pwd', 'Adm1nistrator++!!');
+		$oRemoteApplication->DBWrite();
+		
+		$oAction = new ActioniTopWebhook();
+		$oAction->Set('remoteapplicationconnection_id', $oRemoteApplication->GetKey());
+		$oAction->Set('test_remoteapplicationconnection_id', $oRemoteApplication->GetKey());
+		$oAction->Set('name', 'test');
+		$oAction->DBWrite();
+		
+		$oLog = new EventNotification();
+		
+		$aHeaders = $this->InvokeNonPublicMethod(get_class($oAction), 'PrepareHeaders', $oAction, [[], &$oLog]);
+		$this->assertEquals(['Content-type: application/json', 'Authorization: Basic YWRtaW5pc3RyYXRvcjpBZG0xbmlzdHJhdG9yKyshIQ=='], $aHeaders);
+
+		// iTop connexion via a token
+		$oRemoteApplicationToken = new RemoteiTopConnectionToken();
+		$oRemoteApplicationToken->Set('name', 'Test iTop');
+		$oRemoteApplicationToken->Set('remoteapplicationtype_id', $oRemoteApplicationType->GetKey());
+		$oRemoteApplicationToken->Set('url', 'https://www.combodo.com');
+		$oRemoteApplicationToken->Set('token', 'HAhq2Zfyr24ge!/jqsdf)sCf45A');
+		$oRemoteApplicationToken->DBWrite();
+		
+		$oAction2 = new ActioniTopWebhook();
+		$oAction2->Set('remoteapplicationconnection_id', $oRemoteApplicationToken->GetKey());
+		$oAction2->Set('test_remoteapplicationconnection_id', $oRemoteApplicationToken->GetKey());
+		$oAction2->Set('name', 'test2');
+		$oAction2->DBWrite();
+		
+		$oLog = new EventNotification();
+		
+		$aHeaders = $this->InvokeNonPublicMethod(get_class($oAction), 'PrepareHeaders', $oAction2, [[], &$oLog]);
+		$this->assertEquals(['Content-type: application/json', 'Auth-Token: HAhq2Zfyr24ge!/jqsdf)sCf45A'], $aHeaders);
+		
+	}
+}

--- a/test/ActionWebhook/ActionWebhookTest.php
+++ b/test/ActionWebhook/ActionWebhookTest.php
@@ -35,7 +35,7 @@ class ActionWebhookTest extends ItopDataTestCase
 		parent::setUp();
 	}
 
-	public function testPrepareHeader()
+	public function testPrepareHeaderWithUserAndPassword()
 	{
 		$oRemoteApplicationType = new RemoteApplicationType();
 		$oRemoteApplicationType->Set('name', 'iTop');
@@ -60,7 +60,15 @@ class ActionWebhookTest extends ItopDataTestCase
 		
 		$aHeaders = $this->InvokeNonPublicMethod(get_class($oAction), 'PrepareHeaders', $oAction, [[], &$oLog]);
 		$this->assertEquals(['Content-type: application/json', 'Authorization: Basic YWRtaW5pc3RyYXRvcjpBZG0xbmlzdHJhdG9yKyshIQ=='], $aHeaders);
+		
+	}
 
+	public function testPrepareHeaderWithToken()
+	{
+		$oRemoteApplicationType = new RemoteApplicationType();
+		$oRemoteApplicationType->Set('name', 'iTop');
+		$oRemoteApplicationType->DBWrite();
+		
 		// iTop connexion via a token
 		$oRemoteApplicationToken = new RemoteiTopConnectionToken();
 		$oRemoteApplicationToken->Set('name', 'Test iTop');
@@ -69,15 +77,15 @@ class ActionWebhookTest extends ItopDataTestCase
 		$oRemoteApplicationToken->Set('token', 'HAhq2Zfyr24ge!/jqsdf)sCf45A');
 		$oRemoteApplicationToken->DBWrite();
 		
-		$oAction2 = new ActioniTopWebhook();
-		$oAction2->Set('remoteapplicationconnection_id', $oRemoteApplicationToken->GetKey());
-		$oAction2->Set('test_remoteapplicationconnection_id', $oRemoteApplicationToken->GetKey());
-		$oAction2->Set('name', 'test2');
-		$oAction2->DBWrite();
+		$oAction = new ActioniTopWebhook();
+		$oAction->Set('remoteapplicationconnection_id', $oRemoteApplicationToken->GetKey());
+		$oAction->Set('test_remoteapplicationconnection_id', $oRemoteApplicationToken->GetKey());
+		$oAction->Set('name', 'test2');
+		$oAction->DBWrite();
 		
 		$oLog = new EventNotification();
 		
-		$aHeaders = $this->InvokeNonPublicMethod(get_class($oAction), 'PrepareHeaders', $oAction2, [[], &$oLog]);
+		$aHeaders = $this->InvokeNonPublicMethod(get_class($oAction), 'PrepareHeaders', $oAction, [[], &$oLog]);
 		$this->assertEquals(['Content-type: application/json', 'Auth-Token: HAhq2Zfyr24ge!/jqsdf)sCf45A'], $aHeaders);
 		
 	}

--- a/test/ci_description.ini
+++ b/test/ci_description.ini
@@ -22,7 +22,7 @@ itop_setup=test/setup_params/install_27.xml
 [phpunit]
 ; when empty phpunit_xml => no phpunit test performed
 ; phpunit xml file description. required for phpunit testing
-;phpunit_xml=test/phpunit.xml
+phpunit_xml=test/phpunit.xml
 
 ; by default all tests if not provided
 ;phpunit_suite[]=testsU

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -1,32 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
-        bootstrap="../unittestautoload.php"
-        backupGlobals="true"
-        colors="true"
-        columns="120"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        processIsolation="false"
-        stopOnError="false"
-        stopOnFailure="false"
-        stopOnIncomplete="false"
-        stopOnRisky="false"
-        stopOnSkipped="false"
-        verbose="true"
-        printerClass="\Sempro\PHPUnitPrettyPrinter\PrettyPrinterForPhpUnit9"
->
-  <php>
-    <ini name="error_reporting" value="E_ALL &amp; ~E_DEPRECATED"/>
-    <ini name="display_errors" value="On"/>
-    <ini name="log_errors" value="On"/>
-    <ini name="html_errors" value="Off"/>
-  </php>
+<phpunit bootstrap="../unittestautoload.php" backupGlobals="false" verbose="true">
   <testsuites>
     <testsuite name="testsU">
-      <directory suffix="Test.php">.</directory>
+       <directory suffix="Test.php">.</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+        bootstrap="../unittestautoload.php"
+        backupGlobals="true"
+        colors="true"
+        columns="120"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        processIsolation="false"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnRisky="false"
+        stopOnSkipped="false"
+        verbose="true"
+        printerClass="\Sempro\PHPUnitPrettyPrinter\PrettyPrinterForPhpUnit9"
+>
+  <php>
+    <ini name="error_reporting" value="E_ALL &amp; ~E_DEPRECATED"/>
+    <ini name="display_errors" value="On"/>
+    <ini name="log_errors" value="On"/>
+    <ini name="html_errors" value="Off"/>
+  </php>
+  <testsuites>
+    <testsuite name="testsU">
+      <directory suffix="Test.php">.</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>


### PR DESCRIPTION
This PR adds support of personal/application tokens (provided by the separate extension "authent-tokens") to the iTop Webhooks.