### PR TITLE
N°6305 Fix export of RemoteApplicationConnection and ActionWebhook

### DIFF
--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -62,7 +62,7 @@
 				<reconciliation>
 					<attributes>
 						<attribute id="name"/>
-						<attribute id="application"/>
+						<attribute id="remoteapplicationtype_id"/>
 						<attribute id="environment"/>
 					</attributes>
 				</reconciliation>
@@ -175,7 +175,7 @@
 				<reconciliation>
 					<attributes>
 						<attribute id="name"/>
-						<attribute id="application"/>
+						<attribute id="remoteapplicationtype_id"/>
 						<attribute id="environment"/>
 					</attributes>
 				</reconciliation>


### PR DESCRIPTION
While trying to csv export `ActionWebhook` objects, you would get the following error:
> Error: Unknown attribute application from class RemoteApplicationConnection