### PR TITLE
N°5472 Check JSON payload in CheckToWrite (v2)

### DIFF
--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -673,7 +673,7 @@
 	 * IMPORTANT: The array must be NON associative, otherwise the cURL lib. won't use it.
 	 *
 	 * @param array              $aContextArgs
-	 * @param \EventNotification $oLog
+	 * @param \EventNotification $oLog Can be used to modify notification log
 	 *
 	 * @return array
 	 * @throws \ArchivedObjectException
@@ -681,27 +681,13 @@
 	 */]]></comment>
 					<code><![CDATA[	protected function PrepareHeaders(array $aContextArgs, \EventNotification &$oLog)
 	{
-		$aHeaders = [];
-
 		$sHeadersAsText = MetaModel::ApplyParams($this->Get('headers'), $aContextArgs);
-		$aLines = preg_split('/\r\n|\r|\n/', $sHeadersAsText);
-		foreach ($aLines as $sLine) {
-			$sLine = trim($sLine);
-			if (empty($sLine)) {
-				continue;
-			}
 
-			$aHeaders[] = $sLine;
-		}
-
-		if (count($aHeaders) === 0) {
-			$aHeaders[] = 'Content-type: application/json';
-		}
+		$aHeaders = $this->HeadersStringToArray($sHeadersAsText);
 
 		// Retrieve connection, to let it add some extra headers (e.g. authentication)
 		$oRemoteApplicationconnection = $this->GetRemoteApplicationConnection();
 		$aExtraHeaders = $oRemoteApplicationconnection->PrepareHeaders($aContextArgs, $oLog);
-
 		foreach($aExtraHeaders as $sExtraHeader)
 		{
 			$aHeaders[] = $sExtraHeader;
@@ -737,13 +723,7 @@
 			// Convert / encode payload depending on the content-type header
 			$sContentType = null;
 			$aHeaders = $this->PrepareHeaders($aContextArgs, $oLog);
-			foreach ($aHeaders as $sHeader) {
-				preg_match('/(Content-type)[\s]*:[\s]*(.*)/', $sHeader, $aMatches);
-			    if (strlen($aMatches[2]) > 0){
-					$sContentType = $aMatches[2];
-					break;
-				}
-			}
+			$sContentType = $this->GetContentType($aHeaders);
 
 			switch ($sContentType) {
 				case 'application/json':
@@ -780,6 +760,34 @@
 		}
 
 		return $payload;
+	}
+]]>
+					</code>
+				</method>
+				<method id="HeadersStringToArray">
+					<static>false</static>
+					<access>protected</access>
+					<type>Overload-DBObject</type>
+					<comment><![CDATA[/**
+	 * @param string sHeadersAsText
+	 * @return string[] one header per line
+	 */]]></comment>
+					<code><![CDATA[	protected function HeadersStringToArray($sHeadersAsText)
+	{
+		$aHeaders = [];
+		$aLines = preg_split('/\r\n|\r|\n/', $sHeadersAsText);
+		foreach ($aLines as $sLine) {
+			$sLine = trim($sLine);
+			if (empty($sLine)) {
+				continue;
+			}
+			$aHeaders[] = $sLine;
+		}
+		if (count($aHeaders) === 0) {
+			$aHeaders[] = 'Content-type: application/json';
+		}
+
+		return $aHeaders;
 	}
 ]]>
 					</code>
@@ -851,16 +859,33 @@
 		$aPreparedData = [];
 		foreach ($aInputData as $sKey => $value) {
 			$sPreparedKey = MetaModel::ApplyParams($sKey, $aContextArgs);
-			
-			// N°5367 - Fix non-string values (boolean, null) converted into empty string
-			// Some APIs explicitly require booleans such as 'false'; or null values.
-			// Do not convert those into a string by calling MetaModel::ApplyParams().
-			$preparedValue = is_array($value) ? $this->ApplyParamsToArray($aContextArgs, $value) : (is_string($value) ? MetaModel::ApplyParams($value, $aContextArgs) : $value);
-
-			$aPreparedData[$sPreparedKey] = $preparedValue;
+			$aPreparedData[$sPreparedKey] = $this->ApplyParamsToValue($aContextArgs, $value);
 		}
 
 		return $aPreparedData;
+	}
+]]>
+					</code>
+				</method>
+				<method id="ApplyParamsToValue">
+					<static>false</static>
+					<access>protected</access>
+					<type>Overload-DBObject</type>
+					<comment><![CDATA[/**
+ * Apply $aContextParams recursively to $aInputData
+	 * @param array $aContextArgs List of args to be used by {@see \MetaModel::ApplyParams}
+	 * @param mixed $value Data to apply params to
+	 *
+	 * @see \MetaModel::ApplyParams
+	 * @return array Same structure as $aInputData but with applied params
+	 */]]></comment>
+					<code><![CDATA[	protected function ApplyParamsToValue(array $aContextArgs, $value)
+	{
+		// N°5367 - Fix non-string values (boolean, null) converted into empty string
+		// Some APIs explicitly require booleans such as 'false'; or null values.
+		// Do not convert those into a string by calling MetaModel::ApplyParams().
+		$preparedValue = is_array($value) ? $this->ApplyParamsToArray($aContextArgs, $value) : (is_string($value) ? MetaModel::ApplyParams($value, $aContextArgs) : $value);
+		return $preparedValue;
 	}
 ]]>
 					</code>
@@ -870,26 +895,30 @@
 					<access>protected</access>
 					<type>Overload-DBObject</type>
 					<comment><![CDATA[/**
-	 * Apply $aContextParams to $sInputAsJson
-	 * @param array $aContextArgs
-	 * @param array $sInputAsJson JSON string to apply params to
+	 * @param array $aContextArgs List of args to be used by {@see \MetaModel::ApplyParams}
+	 * @param string $sInputAsJson JSON string possibly containing placeholders
 	 *
-	 * @see \MetaModel::ApplyParams
-	 * @return string Same string as $sInputAsJson but with applied params
+	 * @return string Input string with replaced placeholders
 	 *
-	 * @throw InvalidJsonValueException if payload has an invalid format
+	 * @throw WebhookInvalidJsonValueException if replaced input has an invalid format
 	 *
-	 * @uses json_decode
+	 * @uses static::ApplyParamsToValue
+	 * @uses static::JsonDecodeWithError
 	 * @uses json_encode
-	 * @uses ApplyParamsToArray
 	 *
-	 * @since 1.1.2 N°5473 in case invalid JSON : replace Exception by WebhookInvalidJsonValueException, and more data logged (IssueLog)
+	 * @link https://www.itophub.io/wiki/page?id=latest:admin:placeholders Placeholders documentation
+	 *
+	 * @since 1.2.0 N°5473 In case of invalid JSON : replace Exception by WebhookInvalidJsonValueException, and more data logged (IssueLog)
+	 * @since 1.2.1 N°5472 Replace placeholders before trying to decode
 	 */]]></comment>
 					<code><![CDATA[
 protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 	{
-		$aInputAsArray = json_decode($sInputAsJson, true);
-		if (false === is_array($aInputAsArray)) {
+		$sReplacedInput = $this->ApplyParamsToValue($aContextArgs, $sInputAsJson);
+
+		try{
+			$decodedJson = static::JsonDecodeWithError($sReplacedInput);
+		} catch(Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException $e) {
 			// LogChannels class and NOTIFICATIONS constant were introduced recently, we can't use it with a 2.7.0 compatibility
 			$sLogChannel = 'notifications';
 			$aLogContext = [
@@ -905,8 +934,7 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 			throw new Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException('Wrong JSON format for input, see error log for more information.');
 		}
 
-		$aPreparedDataAsArray = $this->ApplyParamsToArray($aContextArgs, $aInputAsArray);
-		$sPreparedDataAsJson = json_encode($aPreparedDataAsArray);
+		$sPreparedDataAsJson = json_encode($decodedJson);
 
 		return $sPreparedDataAsJson;
 	}
@@ -961,6 +989,75 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 					<code><![CDATA[	public function HasProcessResponseCallback()
 	{
 		return strlen($this->Get('process_response_callback')) > 0;
+	}
+]]>
+					</code>
+				</method>
+				<method id="GetContentType">
+					<static>false</static>
+					<access>protected</access>
+					<type>Overload-DBObject</type>
+					<comment><![CDATA[/**
+	 * @param array $aHeaders
+	 * @return null|string null if nothing found
+	 * @since 1.2.1 N°5472
+	 */]]></comment>
+					<code><![CDATA[	protected function GetContentType($aHeaders)
+	{
+		foreach ($aHeaders as $sHeader) {
+			if (preg_match('/(Content-type)[\s]*:[\s]*(\S+)/', $sHeader, $aMatches)) {
+				return $aMatches[2];
+			}
+		}
+
+		return null;
+	}
+]]>
+					</code>
+				</method>
+				<method id="DoCheckToWrite">
+					<static>false</static>
+					<access>public</access>
+					<type>Overload-DBObject</type>
+					<comment><![CDATA[/**
+	 * Check payload JSON
+	 * @since 1.2.1 N°5472
+	 */]]></comment>
+					<code><![CDATA[	public function DoCheckToWrite()
+	{
+		parent::DoCheckToWrite();
+
+		if (get_class($this) === ActionWebhook::class) {
+			// We don't know what the subclasses will do !
+			// If you need the check in your impl, just implement your own DoCheckToWrite and call the below method
+			$this->DoCheckPayload();
+		}
+	}
+]]>
+					</code>
+				</method>
+				<method id="DoCheckPayload">
+					<static>false</static>
+					<access>public</access>
+					<type>Overload-DBObject</type>
+					<comment><![CDATA[/**
+	 * Check payload JSON
+	 * @since 1.2.1 N°5472
+	 */]]></comment>
+					<code><![CDATA[	public function DoCheckPayload()
+	{
+		// Here we don't have the notification source object... so we won't detect content-type that are fixed with the $this placeholder :/
+		$sHeadersAsText = $this->Get('headers');
+		$aHeaders = $this->HeadersStringToArray($sHeadersAsText);
+		$sContentType = $this->GetContentType($aHeaders);
+		if ($sContentType === 'application/json'){
+			$sPayload = $this->Get('payload');
+			try{
+				static::JsonDecodeWithError($sPayload);
+			} catch(Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException $e){
+				$this->m_aCheckWarnings[] = Dict::S('Class:ActionWebhook:Error:payload:InvalidJson');
+			}
+		}
 	}
 ]]>
 					</code>

--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -909,7 +909,7 @@
 	 * @link https://www.itophub.io/wiki/page?id=latest:admin:placeholders Placeholders documentation
 	 *
 	 * @since 1.2.0 N°5473 In case of invalid JSON : replace Exception by WebhookInvalidJsonValueException, and more data logged (IssueLog)
-	 * @since 1.2.1 N°5472 Replace placeholders before trying to decode
+	 * @since 1.3.2 N°5472 Replace placeholders before trying to decode
 	 */]]></comment>
 					<code><![CDATA[
 protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
@@ -1000,7 +1000,7 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 					<comment><![CDATA[/**
 	 * @param array $aHeaders
 	 * @return null|string null if nothing found
-	 * @since 1.2.1 N°5472
+	 * @since 1.3.2 N°5472 method creation
 	 */]]></comment>
 					<code><![CDATA[	protected function GetContentType($aHeaders)
 	{
@@ -1021,7 +1021,7 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 					<type>Overload-DBObject</type>
 					<comment><![CDATA[/**
 	 * Check payload JSON
-	 * @since 1.2.1 N°5472
+	 * @since 1.3.2 N°5472 method creation
 	 */]]></comment>
 					<code><![CDATA[	public function DoCheckToWrite()
 	{
@@ -1042,7 +1042,7 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 					<type>Overload-DBObject</type>
 					<comment><![CDATA[/**
 	 * @uses DoCheckPayLoad
-	 * @since 1.2.1 N°5472
+	 * @since 1.3.2 N°5472 method creation
 	 */]]></comment>
 					<code><![CDATA[	public function DoCheckPayloadForJsonContentType()
 	{
@@ -1063,7 +1063,7 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 					<type>Overload-DBObject</type>
 					<comment><![CDATA[/**
 	 * Check payload JSON
-	 * @since 1.2.1 N°5472
+	 * @since 1.3.2 N°5472 method creation
 	 */]]></comment>
 					<code><![CDATA[	public function DoCheckPayload()
 	{
@@ -1291,7 +1291,7 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 					<type>Overload-DBObject</type>
 					<comment><![CDATA[/**
 	 * Check payload JSON
-	 * @since 1.2.1 N°5472
+	 * @since 1.3.2 N°5472 method creation
 	 */]]></comment>
 					<code><![CDATA[	public function DoCheckToWrite()
 	{

--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -1030,34 +1030,18 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 		if (get_class($this) === ActionWebhook::class) {
 			// We don't know what the subclasses will do !
 			// If you need the check in your impl, just implement your own DoCheckToWrite and call the below method
-			$this->DoCheckPayloadForJsonContentType();
+			$sHeadersAsText = $this->Get('headers');
+			$aHeaders = $this->HeadersStringToArray($sHeadersAsText);
+			$sContentType = $this->GetContentType($aHeaders);
+			if ($sContentType === 'application/json'){
+				$this->CheckPayloadIsValid();
+			}
 		}
 	}
 ]]>
 					</code>
 				</method>
-				<method id="DoCheckPayloadForJsonContentType">
-					<static>false</static>
-					<access>public</access>
-					<type>Overload-DBObject</type>
-					<comment><![CDATA[/**
-	 * @uses DoCheckPayLoad
-	 * @since 1.3.2 N°5472 method creation
-	 */]]></comment>
-					<code><![CDATA[	public function DoCheckPayloadForJsonContentType()
-	{
-		// Here we don't have the notification source object... so we won't detect content-type that are fixed with the $this placeholder :/
-		$sHeadersAsText = $this->Get('headers');
-		$aHeaders = $this->HeadersStringToArray($sHeadersAsText);
-		$sContentType = $this->GetContentType($aHeaders);
-		if ($sContentType === 'application/json'){
-			$this->DoCheckPayload();
-		}
-	}
-]]>
-					</code>
-				</method>
-				<method id="DoCheckPayload">
+				<method id="CheckPayloadIsValid">
 					<static>false</static>
 					<access>public</access>
 					<type>Overload-DBObject</type>
@@ -1065,7 +1049,7 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 	 * Check payload JSON
 	 * @since 1.3.2 N°5472 method creation
 	 */]]></comment>
-					<code><![CDATA[	public function DoCheckPayload()
+					<code><![CDATA[	public function CheckPayloadIsValid()
 	{
 		$sPayload = $this->Get('payload');
 		try{
@@ -1297,7 +1281,7 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 	{
 		parent::DoCheckToWrite();
 
-		$this->DoCheckPayload();
+		$this->CheckPayloadIsValid();
 	}
 ]]>
 					</code>

--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -1005,7 +1005,7 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 					<code><![CDATA[	protected function GetContentType($aHeaders)
 	{
 		foreach ($aHeaders as $sHeader) {
-			if (preg_match('/(Content-type)[\s]*:[\s]*(\S+)/', $sHeader, $aMatches)) {
+			if (preg_match('/(Content-type)\s*:\s*(\S+)/', $sHeader, $aMatches)) {
 				return $aMatches[2];
 			}
 		}

--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -1030,6 +1030,27 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 		if (get_class($this) === ActionWebhook::class) {
 			// We don't know what the subclasses will do !
 			// If you need the check in your impl, just implement your own DoCheckToWrite and call the below method
+			$this->DoCheckPayloadForJsonContentType();
+		}
+	}
+]]>
+					</code>
+				</method>
+				<method id="DoCheckPayloadForJsonContentType">
+					<static>false</static>
+					<access>public</access>
+					<type>Overload-DBObject</type>
+					<comment><![CDATA[/**
+	 * @uses DoCheckPayLoad
+	 * @since 1.2.1 N°5472
+	 */]]></comment>
+					<code><![CDATA[	public function DoCheckPayloadForJsonContentType()
+	{
+		// Here we don't have the notification source object... so we won't detect content-type that are fixed with the $this placeholder :/
+		$sHeadersAsText = $this->Get('headers');
+		$aHeaders = $this->HeadersStringToArray($sHeadersAsText);
+		$sContentType = $this->GetContentType($aHeaders);
+		if ($sContentType === 'application/json'){
 			$this->DoCheckPayload();
 		}
 	}
@@ -1046,17 +1067,11 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 	 */]]></comment>
 					<code><![CDATA[	public function DoCheckPayload()
 	{
-		// Here we don't have the notification source object... so we won't detect content-type that are fixed with the $this placeholder :/
-		$sHeadersAsText = $this->Get('headers');
-		$aHeaders = $this->HeadersStringToArray($sHeadersAsText);
-		$sContentType = $this->GetContentType($aHeaders);
-		if ($sContentType === 'application/json'){
-			$sPayload = $this->Get('payload');
-			try{
-				static::JsonDecodeWithError($sPayload);
-			} catch(Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException $e){
-				$this->m_aCheckWarnings[] = Dict::S('Class:ActionWebhook:Error:payload:InvalidJson');
-			}
+		$sPayload = $this->Get('payload');
+		try{
+			static::JsonDecodeWithError($sPayload);
+		} catch(Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException $e){
+			$this->m_aCheckWarnings[] = Dict::S('Class:ActionWebhook:Error:payload:InvalidJson');
 		}
 	}
 ]]>
@@ -1270,6 +1285,24 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 ]]>
 					</code>
 				</method>
+				<method id="DoCheckToWrite">
+					<static>false</static>
+					<access>public</access>
+					<type>Overload-DBObject</type>
+					<comment><![CDATA[/**
+	 * Check payload JSON
+	 * @since 1.2.1 N°5472
+	 */]]></comment>
+					<code><![CDATA[	public function DoCheckToWrite()
+	{
+		parent::DoCheckToWrite();
+
+		$this->DoCheckPayload();
+	}
+]]>
+					</code>
+				</method>
+
 			</methods>
 			<presentation>
 				<details>

--- a/en.dict.combodo-webhook-integration.php
+++ b/en.dict.combodo-webhook-integration.php
@@ -86,6 +86,7 @@ You can use 2 types of methods:
 - From the triggering object itself (eg. UserRequest), must be public. Example: $this->XXX($oResponse, $oAction)
 - From any PHP class, must be static AND public. Name must be name fully qualified. Example: \SomeClass::XXX($oObject, $oResponse, $oAction)
 - $oResponse can be null in some cases (eg. request failed to send)',
+	'Class:ActionWebhook:Error:payload:InvalidJson' => 'Warning: The payload field contains an invalid JSON value, the action might fail.',
 	// - Fieldsets
 	'ActionWebhook:baseinfo' => 'General information',
 	'ActionWebhook:moreinfo' => 'More information',

--- a/fr.dict.combodo-webhook-integration.php
+++ b/fr.dict.combodo-webhook-integration.php
@@ -87,7 +87,8 @@ IMPORTANT : Vous pouvez utiliser 2 types de méthodes :
 - Méthode de l\'objet déclenchant l\'action (ex : Demande utilisateur), doit être publique. Example : $this->XXX($oResponse, $oAction)
 - Méthode de n\'importe quelle classe PHP, doit être statique ET publique. Le nom doit être entièrement qualifié (inclure le namespace). Exemple : \\UneClass::XXX($oObject, $oResponse, $oAction)
 - $oResponse peut être null dans certains cas (ex : échec de l\'envoi de la requête)',
-    // - Fieldsets
+	'Class:ActionWebhook:Error:payload:InvalidJson' => 'Attention : Le champ Charge Utile contient un JSON invalide, l\'action pourrait ne pas être exécutée.',
+	// - Fieldsets
 	'ActionWebhook:baseinfo' => 'Informations générales',
 	'ActionWebhook:moreinfo' => 'Autres informations',
 	'ActionWebhook:webhookconnection' => 'Informations de connexion',

--- a/src/Core/Notification/Action/_ActionWebhook.php
+++ b/src/Core/Notification/Action/_ActionWebhook.php
@@ -4,6 +4,7 @@ namespace Combodo\iTop\Core\Notification\Action;
 
 use ActionNotification;
 use ApplicationContext;
+use Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException;
 use Combodo\iTop\Core\WebResponse;
 use Combodo\iTop\Service\WebRequestSender;
 use EventWebhook;
@@ -196,7 +197,7 @@ abstract class _ActionWebhook extends ActionNotification
 	}
 
 	/**
-	 * @param array              $aContextArgs
+	 * @param array $aContextArgs
 	 * @param \EventNotification $oLog
 	 *
 	 * @return \Combodo\iTop\Core\WebRequest Prepare and return the WebRequest to be sent
@@ -204,4 +205,32 @@ abstract class _ActionWebhook extends ActionNotification
 	 * @throws \CoreException
 	 */
 	abstract protected function PrepareWebRequest(array $aContextArgs, \EventNotification &$oLog);
+
+	/**
+	 * @param mixed $sJson
+	 *
+	 * @return string|array|boolean|null decoded value
+	 * @throws WebhookInvalidJsonValueException if error on decode
+	 *
+	 * @uses json_decode
+	 * @uses json_last_error
+	 *
+	 * @link https://www.json.org/json-en.html JSON can contain an object, but also null, or boolean or string values
+	 * @link https://www.php.net/manual/en/function.json-last-error.php for JSON error codes
+	 *
+	 * @since 1.2.1 N°5472
+	 */
+	public static function JsonDecodeWithError($sJson)
+	{
+		$decodedValue = json_decode($sJson, true);
+		$decodeError = json_last_error();
+		if ($decodeError !== JSON_ERROR_NONE) {
+			throw new WebhookInvalidJsonValueException('Invalid JSON format', [
+				'value' => $sJson,
+				'error' => $decodeError,
+			]);
+		}
+
+		return $decodedValue;
+	}
 }

--- a/src/Core/Notification/Action/_ActionWebhook.php
+++ b/src/Core/Notification/Action/_ActionWebhook.php
@@ -218,7 +218,7 @@ abstract class _ActionWebhook extends ActionNotification
 	 * @link https://www.json.org/json-en.html JSON can contain an object, but also null, or boolean or string values
 	 * @link https://www.php.net/manual/en/function.json-last-error.php for JSON error codes
 	 *
-	 * @since 1.2.1 N°5472
+	 * @since 1.3.2 N°5472 method creation
 	 */
 	public static function JsonDecodeWithError($sJson)
 	{

--- a/tests/php-unit-tests/ActionWebhookTest.php
+++ b/tests/php-unit-tests/ActionWebhookTest.php
@@ -1,27 +1,19 @@
 <?php
 /*
- * Copyright (C) 2023 Combodo SARL
- * This file is part of iTop.
- * iTop is free software; you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- * iTop is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- * You should have received a copy of the GNU Affero General Public License
+ * @copyright   Copyright (C) 2010-2023 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
  */
 
 namespace Combodo\iTop\Core\Test;
 
+use ActioniTopWebhook;
+use ActionWebhook;
+use Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException;
 use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use EventNotification;
+use RemoteApplicationType;
 use RemoteiTopConnection;
 use RemoteiTopConnectionToken;
-use RemoteApplicationType;
-use ActioniTopWebhook;
-use EventNotification;
-use MetaModel;
 
 
 /**
@@ -49,18 +41,18 @@ class ActionWebhookTest extends ItopDataTestCase
 		$oRemoteApplication->Set('auth_user', 'administrator');
 		$oRemoteApplication->Set('auth_pwd', 'Adm1nistrator++!!');
 		$oRemoteApplication->DBWrite();
-		
+
 		$oAction = new ActioniTopWebhook();
 		$oAction->Set('remoteapplicationconnection_id', $oRemoteApplication->GetKey());
 		$oAction->Set('test_remoteapplicationconnection_id', $oRemoteApplication->GetKey());
 		$oAction->Set('name', 'test');
 		$oAction->DBWrite();
-		
+
 		$oLog = new EventNotification();
-		
+
 		$aHeaders = $this->InvokeNonPublicMethod(get_class($oAction), 'PrepareHeaders', $oAction, [[], &$oLog]);
 		$this->assertEquals(['Content-type: application/json', 'Authorization: Basic YWRtaW5pc3RyYXRvcjpBZG0xbmlzdHJhdG9yKyshIQ=='], $aHeaders);
-		
+
 	}
 
 	public function testPrepareHeaderWithToken()
@@ -68,7 +60,7 @@ class ActionWebhookTest extends ItopDataTestCase
 		$oRemoteApplicationType = new RemoteApplicationType();
 		$oRemoteApplicationType->Set('name', 'iTop');
 		$oRemoteApplicationType->DBWrite();
-		
+
 		// iTop connexion via a token
 		$oRemoteApplicationToken = new RemoteiTopConnectionToken();
 		$oRemoteApplicationToken->Set('name', 'Test iTop');
@@ -76,17 +68,79 @@ class ActionWebhookTest extends ItopDataTestCase
 		$oRemoteApplicationToken->Set('url', 'https://www.combodo.com');
 		$oRemoteApplicationToken->Set('token', 'HAhq2Zfyr24ge!/jqsdf)sCf45A');
 		$oRemoteApplicationToken->DBWrite();
-		
+
 		$oAction = new ActioniTopWebhook();
 		$oAction->Set('remoteapplicationconnection_id', $oRemoteApplicationToken->GetKey());
 		$oAction->Set('test_remoteapplicationconnection_id', $oRemoteApplicationToken->GetKey());
 		$oAction->Set('name', 'test2');
 		$oAction->DBWrite();
-		
+
 		$oLog = new EventNotification();
-		
+
 		$aHeaders = $this->InvokeNonPublicMethod(get_class($oAction), 'PrepareHeaders', $oAction, [[], &$oLog]);
 		$this->assertEquals(['Content-type: application/json', 'Auth-Token: HAhq2Zfyr24ge!/jqsdf)sCf45A'], $aHeaders);
-		
+
+	}
+
+	/**
+	 * @dataProvider ApplyParamsToJsonProvider
+	 */
+	public function testApplyParamsToJson($json, bool $bExpectException, $expected = null, array $aContextArgs = [])
+	{
+		if ($bExpectException) {
+			$this->expectException(WebhookInvalidJsonValueException::class);
+		}
+
+		$oActionWebhook = new ActionWebhook();
+		$result = $this->InvokeNonPublicMethod(ActionWebhook::class, 'ApplyParamsToJson', $oActionWebhook,
+			[$aContextArgs, $json]);
+
+		if (false === $bExpectException) {
+			$this->assertSame($expected, $result);
+		}
+	}
+
+	public function ApplyParamsToJsonProvider(): array
+	{
+		return [
+			'String Param not replaced' => ['$this->value$', true],
+			'String Param replaced' => ['$this->value$', false, '"toto"', ['this->value' => '"toto"']],
+
+			'Array quotes in value Param not replaced' => ['{"value":$this->value$}', true],
+			'Array quotes in value Param replaced' => ['{"value":$this->value$}', false, '{"value":"toto"}', ['this->value' => '"toto"']],
+
+			'Array quotes in json Param not replaced' => ['{"value":"$this->value$"}', false, '{"value":"$this->value$"}', []],
+			'Array quotes in json Param replaced' => ['{"value":"$this->value$"}', false, '{"value":"toto"}', ['this->value' => 'toto']],
+		];
+	}
+
+	/**
+	 * @dataProvider GetContentTypeProvider
+	 */
+	public function testGetContentType($sInput, $expectedReturnedContentType)
+	{
+		$aHeaders = [$sInput];
+
+		$oActionWebhook = new ActionWebhook();
+		$result = $this->InvokeNonPublicMethod(ActionWebhook::class, 'GetContentType', $oActionWebhook,
+			[$aHeaders]);
+
+		$this->assertSame($expectedReturnedContentType, $result);
+	}
+
+	public function GetContentTypeProvider()
+	{
+		return [
+			'null' => [null, null],
+			'empty string' => ['', null],
+
+			'typo in header' => ['ContentTypo:application/json', null],
+
+			'correct header JSON' => ['Content-type:application/json', 'application/json'],
+			'correct header JSON with spaces and tab' => ['Content-type   :		   application/json', 'application/json'],
+
+			'header no value' => ['Content-type:', null],
+			'header value only spaces and tab' => ['Content-type:   	    ', null],
+		];
 	}
 }

--- a/tests/php-unit-tests/_ActionWebhookTest.php
+++ b/tests/php-unit-tests/_ActionWebhookTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * @copyright   Copyright (C) 2010-2023 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\Test\UnitTest\Core;
+
+use Combodo\iTop\Core\Notification\Action\_ActionWebhook;
+use Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException;
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+
+class _ActionWebhookTest extends ItopTestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		// no datamodel loaded so we need to include module file manually
+		$this->RequireOnceItopFile('env-production/combodo-webhook-integration/src/Core/Notification/Action/_ActionWebhook.php');
+		$this->RequireOnceItopFile('env-production/combodo-webhook-integration/src/Core/Notification/Action/Webhook/Exception/WebhookInvalidJsonValueException.php');
+	}
+
+	/**
+	 * @param ?string|boolean $sJson
+	 * @param false|array $expected
+	 *
+	 * @return void
+	 *
+	 * @dataProvider IsJsonValidProvider
+	 */
+	public function testIsJsonValid($json, $bExpectException, $expected = null) {
+		if ($bExpectException) {
+			$this->expectException(WebhookInvalidJsonValueException::class);
+		}
+		$result = _ActionWebhook::JsonDecodeWithError($json);
+
+		if (false === $bExpectException) {
+			$this->assertSame($expected, $result);
+		}
+	}
+
+	public function IsJsonValidProvider() {
+		return [
+			'null' => [null, true],
+
+			'false' => [false, true],
+			'true' => [true, false, 1],
+
+			'null string' => ['null', false, null],
+			'false string' => ['false', false, false],
+			'true string' => ['true', false, true],
+			'string without quotes' => ['foobar', true],
+			'string with quotes' => ['"foobar"', false, 'foobar'],
+
+			'simple array' => ['{"foo":"bar"}', false, ['foo' => 'bar']],
+			'invalid array' => ['{foo:bar}', true],
+		];
+	}
+}


### PR DESCRIPTION
Report of modifications done in #8 but that were difficult to merge :/

Description copy : 

Since N°4753 and version 1.1.0 the JSON payload validity are checked when the action is processed (ActionWebhook::ApplyParamsToJson)

This is usefull, but the action author is warned at the very last moment that he made a mistake in its JSON value...
Also, only JSON objects are validated, not boolean, null or string values.

This PR adds a DoCheckToWrite method that checks JSON validity directly when saving the action.
The check is non blocking, as in the DoCheckToWrite we cannot apply params...
Example : 

![image](https://user-images.githubusercontent.com/8947448/235616998-2711d92f-8a27-4664-b445-1306a198633e.png)

Sample JSON : 

```json
{
    "trueValue":true,
    "numericUnquotedValue":2,
    "numericPlaceholderUnquotedValue":$this->numericValue$,
    "textValue":"this is some text",
    "invalidTextValue":hop
}
```

TODO : 
- May 2023 Technical review : 
  - [ ] Guillaume will create a modernization ticket for iTop 3.2 to reintegrate the `_ActionWebhook::JsonDecodeWithError` method in the core.
  - [ ] Pierre will enrich the documentation with the meaning of the warning (placeholders for example)
- [ ] May 2023 Functional review : the real problem is when we have placeholders not quoted, like for an integer value. We should detect placeholders and adapt the message in the CheckToWrite !
- [x] Hipska may 2023 comment : simplify GetContentType regexp, use `'/(Content-type)\s*:\s*(\S+)/'` instead of `'/(Content-type)[\s]*:[\s]*(\S+)/'`
