### PR TITLE
N°6647 Improve JSON validity check

### DIFF
--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -901,11 +901,11 @@
 protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 	{
 		// replacing placeholders...
-		$sReplacedInput = $this->ApplyParamsToValue($aContextArgs, $sInputAsJson);
+		$sJsonWithReplacedPlaceholders = $this->ApplyParamsToValue($aContextArgs, $sInputAsJson);
 
 		// and now checking JSON validity !
 		try{
-			$decodedJson = static::JsonDecodeWithError($sReplacedInput);
+			static::JsonDecodeWithError($sJsonWithReplacedPlaceholders);
 		} catch(Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException $e) {
 			// LogChannels class and NOTIFICATIONS constant were introduced recently, we can't use it with a 2.7.0 compatibility
 			$sLogChannel = 'notifications';
@@ -922,7 +922,7 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 			throw new Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException('Wrong JSON format for input, see error log for more information.');
 		}
 
-		return $sReplacedInput;
+		return $sJsonWithReplacedPlaceholders;
 	}
 ]]>
 					</code>

--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -920,9 +920,7 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 			throw new Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException('Wrong JSON format for input, see error log for more information.');
 		}
 
-		$sPreparedDataAsJson = json_encode($decodedJson);
-
-		return $sPreparedDataAsJson;
+		return $sReplacedInput;
 	}
 ]]>
 					</code>

--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -737,13 +737,7 @@
 			// Convert / encode payload depending on the content-type header
 			$sContentType = null;
 			$aHeaders = $this->PrepareHeaders($aContextArgs, $oLog);
-			foreach ($aHeaders as $sHeader) {
-				preg_match('/(Content-type)[\s]*:[\s]*(.*)/', $sHeader, $aMatches);
-			    if (strlen($aMatches[2]) > 0){
-					$sContentType = $aMatches[2];
-					break;
-				}
-			}
+			$sContentType = $this->GetContentType($aHeaders);
 
 			switch ($sContentType) {
 				case 'application/json':
@@ -851,16 +845,33 @@
 		$aPreparedData = [];
 		foreach ($aInputData as $sKey => $value) {
 			$sPreparedKey = MetaModel::ApplyParams($sKey, $aContextArgs);
-			
-			// N°5367 - Fix non-string values (boolean, null) converted into empty string
-			// Some APIs explicitly require booleans such as 'false'; or null values.
-			// Do not convert those into a string by calling MetaModel::ApplyParams().
-			$preparedValue = is_array($value) ? $this->ApplyParamsToArray($aContextArgs, $value) : (is_string($value) ? MetaModel::ApplyParams($value, $aContextArgs) : $value);
-
-			$aPreparedData[$sPreparedKey] = $preparedValue;
+			$aPreparedData[$sPreparedKey] = $this->ApplyParamsToValue($aContextArgs, $value);
 		}
 
 		return $aPreparedData;
+	}
+]]>
+					</code>
+				</method>
+				<method id="ApplyParamsToValue">
+					<static>false</static>
+					<access>protected</access>
+					<type>Overload-DBObject</type>
+					<comment><![CDATA[/**
+	 * Apply $aContextParams recursively to $aInputData
+	 * @param array $aContextArgs List of args to be used by {@see \MetaModel::ApplyParams}
+	 * @param mixed $value Data to apply params to
+	 *
+	 * @see \MetaModel::ApplyParams
+	 * @return array Same structure as $aInputData but with applied params
+	 */]]></comment>
+					<code><![CDATA[	protected function ApplyParamsToValue(array $aContextArgs, $value)
+	{
+		// N°5367 - Fix non-string values (boolean, null) converted into empty string
+		// Some APIs explicitly require booleans such as 'false'; or null values.
+		// Do not convert those into a string by calling MetaModel::ApplyParams().
+		$preparedValue = is_array($value) ? $this->ApplyParamsToArray($aContextArgs, $value) : (is_string($value) ? MetaModel::ApplyParams($value, $aContextArgs) : $value);
+		return $preparedValue;
 	}
 ]]>
 					</code>
@@ -870,26 +881,30 @@
 					<access>protected</access>
 					<type>Overload-DBObject</type>
 					<comment><![CDATA[/**
-	 * Apply $aContextParams to $sInputAsJson
-	 * @param array $aContextArgs
-	 * @param array $sInputAsJson JSON string to apply params to
+	 * @param array $aContextArgs List of args to be used by {@see \MetaModel::ApplyParams}
+	 * @param string $sInputAsJson JSON string possibly containing placeholders
 	 *
-	 * @see \MetaModel::ApplyParams
-	 * @return string Same string as $sInputAsJson but with applied params
+	 * @return string Input string with replaced placeholders
 	 *
-	 * @throw InvalidJsonValueException if payload has an invalid format
+	 * @throw WebhookInvalidJsonValueException if replaced input has an invalid format
 	 *
-	 * @uses json_decode
+	 * @uses static::ApplyParamsToValue
+	 * @uses static::JsonDecodeWithError
 	 * @uses json_encode
-	 * @uses ApplyParamsToArray
 	 *
-	 * @since 1.1.2 N°5473 in case invalid JSON : replace Exception by WebhookInvalidJsonValueException, and more data logged (IssueLog)
+	 * @link https://www.itophub.io/wiki/page?id=latest:admin:placeholders Placeholders documentation
+	 *
+	 * @since 1.2.0 N°5473 In case of invalid JSON : replace Exception by WebhookInvalidJsonValueException, and more data logged (IssueLog)
+	 * @since 1.3.2 N°5472 Replace placeholders before trying to decode
 	 */]]></comment>
 					<code><![CDATA[
 protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 	{
-		$aInputAsArray = json_decode($sInputAsJson, true);
-		if (false === is_array($aInputAsArray)) {
+		$sReplacedInput = $this->ApplyParamsToValue($aContextArgs, $sInputAsJson);
+
+		try{
+			$decodedJson = static::JsonDecodeWithError($sReplacedInput);
+		} catch(Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException $e) {
 			// LogChannels class and NOTIFICATIONS constant were introduced recently, we can't use it with a 2.7.0 compatibility
 			$sLogChannel = 'notifications';
 			$aLogContext = [
@@ -905,8 +920,7 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 			throw new Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException('Wrong JSON format for input, see error log for more information.');
 		}
 
-		$aPreparedDataAsArray = $this->ApplyParamsToArray($aContextArgs, $aInputAsArray);
-		$sPreparedDataAsJson = json_encode($aPreparedDataAsArray);
+		$sPreparedDataAsJson = json_encode($decodedJson);
 
 		return $sPreparedDataAsJson;
 	}
@@ -961,6 +975,28 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 					<code><![CDATA[	public function HasProcessResponseCallback()
 	{
 		return strlen($this->Get('process_response_callback')) > 0;
+	}
+]]>
+					</code>
+				</method>
+				<method id="GetContentType">
+					<static>false</static>
+					<access>protected</access>
+					<type>Overload-DBObject</type>
+					<comment><![CDATA[/**
+	 * @param array $aHeaders
+	 * @return null|string null if nothing found
+	 * @since 1.3.2 N°5472
+	 */]]></comment>
+					<code><![CDATA[	protected function GetContentType($aHeaders)
+	{
+		foreach ($aHeaders as $sHeader) {
+			if (preg_match('/(Content-type)[\s]*:[\s]*(\S+)/', $sHeader, $aMatches)) {
+				return $aMatches[2];
+			}
+		}
+
+		return null;
 	}
 ]]>
 					</code>

--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -895,7 +895,7 @@
 	 * @link https://www.itophub.io/wiki/page?id=latest:admin:placeholders Placeholders documentation
 	 *
 	 * @since 1.2.0 N°5473 In case of invalid JSON : replace Exception by WebhookInvalidJsonValueException, and more data logged (IssueLog)
-	 * @since 1.3.2 N°5472 Replace placeholders before trying to decode
+	 * @since 1.3.2 N°6647 Replace placeholders before trying to decode
 	 */]]></comment>
 					<code><![CDATA[
 protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
@@ -984,7 +984,7 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 					<comment><![CDATA[/**
 	 * @param array $aHeaders
 	 * @return null|string null if nothing found
-	 * @since 1.3.2 N°5472
+	 * @since 1.3.2 N°6647 method creation
 	 */]]></comment>
 					<code><![CDATA[	protected function GetContentType($aHeaders)
 	{

--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -991,7 +991,7 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 					<code><![CDATA[	protected function GetContentType($aHeaders)
 	{
 		foreach ($aHeaders as $sHeader) {
-			if (preg_match('/(Content-type)[\s]*:[\s]*(\S+)/', $sHeader, $aMatches)) {
+			if (preg_match('/(Content-type)\s*:\s*(\S+)/', $sHeader, $aMatches)) {
 				return $aMatches[2];
 			}
 		}

--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -900,8 +900,10 @@
 					<code><![CDATA[
 protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 	{
+		// replacing placeholders...
 		$sReplacedInput = $this->ApplyParamsToValue($aContextArgs, $sInputAsJson);
 
+		// and now checking JSON validity !
 		try{
 			$decodedJson = static::JsonDecodeWithError($sReplacedInput);
 		} catch(Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException $e) {

--- a/src/Core/Notification/Action/_ActionWebhook.php
+++ b/src/Core/Notification/Action/_ActionWebhook.php
@@ -4,6 +4,7 @@ namespace Combodo\iTop\Core\Notification\Action;
 
 use ActionNotification;
 use ApplicationContext;
+use Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException;
 use Combodo\iTop\Core\WebResponse;
 use Combodo\iTop\Service\WebRequestSender;
 use EventWebhook;
@@ -196,7 +197,7 @@ abstract class _ActionWebhook extends ActionNotification
 	}
 
 	/**
-	 * @param array              $aContextArgs
+	 * @param array $aContextArgs
 	 * @param \EventNotification $oLog
 	 *
 	 * @return \Combodo\iTop\Core\WebRequest Prepare and return the WebRequest to be sent
@@ -204,4 +205,32 @@ abstract class _ActionWebhook extends ActionNotification
 	 * @throws \CoreException
 	 */
 	abstract protected function PrepareWebRequest(array $aContextArgs, \EventNotification &$oLog);
+
+	/**
+	 * @param mixed $sJson
+	 *
+	 * @return string|array|boolean|null decoded value
+	 * @throws WebhookInvalidJsonValueException if error on decode
+	 *
+	 * @uses json_decode
+	 * @uses json_last_error
+	 *
+	 * @link https://www.json.org/json-en.html JSON can contain an object, but also null, or boolean or string values
+	 * @link https://www.php.net/manual/en/function.json-last-error.php for JSON error codes
+	 *
+	 * @since 1.2.1 N°5472
+	 */
+	public static function JsonDecodeWithError($sJson)
+	{
+		$decodedValue = json_decode($sJson, true);
+		$decodeError = json_last_error();
+		if ($decodeError !== JSON_ERROR_NONE) {
+			throw new WebhookInvalidJsonValueException('Invalid JSON format', [
+				'value' => $sJson,
+				'error' => $decodeError,
+			]);
+		}
+
+		return $decodedValue;
+	}
 }

--- a/src/Core/Notification/Action/_ActionWebhook.php
+++ b/src/Core/Notification/Action/_ActionWebhook.php
@@ -218,7 +218,7 @@ abstract class _ActionWebhook extends ActionNotification
 	 * @link https://www.json.org/json-en.html JSON can contain an object, but also null, or boolean or string values
 	 * @link https://www.php.net/manual/en/function.json-last-error.php for JSON error codes
 	 *
-	 * @since 1.2.1 N°5472
+	 * @since 1.3.2 N°6647 more generic method to check JSON validity
 	 */
 	public static function JsonDecodeWithError($sJson)
 	{

--- a/src/Core/Notification/Action/_ActionWebhook.php
+++ b/src/Core/Notification/Action/_ActionWebhook.php
@@ -227,7 +227,8 @@ abstract class _ActionWebhook extends ActionNotification
 		if ($decodeError !== JSON_ERROR_NONE) {
 			throw new WebhookInvalidJsonValueException('Invalid JSON format', [
 				'value' => $sJson,
-				'error' => $decodeError,
+				'json_decode.error' => $decodeError,
+				'json_decode.errormessage' => json_last_error_msg(),
 			]);
 		}
 

--- a/src/Core/Notification/Action/_ActionWebhook.php
+++ b/src/Core/Notification/Action/_ActionWebhook.php
@@ -223,6 +223,12 @@ abstract class _ActionWebhook extends ActionNotification
 	 */
 	public static function JsonDecodeWithError($sJson)
 	{
+		if (false === is_string($sJson)) {
+			throw new WebhookInvalidJsonValueException('Input JSON is not a string', [
+				'value' => $sJson,
+			]);
+		}
+
 		$decodedValue = json_decode($sJson, true);
 		$decodeError = json_last_error();
 		if ($decodeError !== JSON_ERROR_NONE) {

--- a/src/Core/Notification/Action/_ActionWebhook.php
+++ b/src/Core/Notification/Action/_ActionWebhook.php
@@ -207,7 +207,7 @@ abstract class _ActionWebhook extends ActionNotification
 	abstract protected function PrepareWebRequest(array $aContextArgs, \EventNotification &$oLog);
 
 	/**
-	 * @param mixed $sJson
+	 * @param string $sJson
 	 *
 	 * @return string|array|boolean|null decoded value
 	 * @throws WebhookInvalidJsonValueException if error on decode
@@ -215,7 +215,8 @@ abstract class _ActionWebhook extends ActionNotification
 	 * @uses json_decode
 	 * @uses json_last_error
 	 *
-	 * @link https://www.json.org/json-en.html JSON can contain an object, but also null, or boolean or string values
+	 * @link https://www.json.org/json-en.html JSON string can contain an object (associative array),
+	 *              but also "null", or boolean ("true" or "false") or any other string values (for example "foo")
 	 * @link https://www.php.net/manual/en/function.json-last-error.php for JSON error codes
 	 *
 	 * @since 1.3.2 N°6647 more generic method to check JSON validity

--- a/tests/php-unit-tests/ActionWebhookTest.php
+++ b/tests/php-unit-tests/ActionWebhookTest.php
@@ -106,14 +106,13 @@ class ActionWebhookTest extends ItopDataTestCase
 			'String Param not replaced' => ['$this->value$', true],
 			'String Param replaced' => ['$this->value$', false, '"toto"', ['this->value' => '"toto"']],
 
-			'Array quotes in value Param not replaced' => ['{"value":$this->value$}', true],
-			'Array quotes in value Param replaced' => ['{"value":$this->value$}', false, '{"value":"toto"}', ['this->value' => '"toto"']],
+			'Array value without quotes Param not replaced' => ['{"value":$this->value$}', true],
+			'Array value without quotes Param replaced with not quoted string' => ['{"value":$this->value$}', true, null, ['this->value' => 'toto']],
+			'Array value without quotes Param replaced with quoted string' => ['{"value":$this->value$}', false, '{"value":"toto"}', ['this->value' => '"toto"']],
+			'Array value without quotes Param replaced with numeric value' => ['{"value":$this->value$}', false, '{"value":2}', ['this->value' => 2]],
 
-			'Array quotes in json Param not replaced' => ['{"value":"$this->value$"}', false, '{"value":"$this->value$"}', []],
-			'Array quotes in json Param replaced' => ['{"value":"$this->value$"}', false, '{"value":"toto"}', ['this->value' => 'toto']],
-
-			'Array int value in json Param not replaced' => ['{"value":$this->value$}', true],
-			'Array int value in json Param replaced' => ['{"value":$this->value$}', false, '{"value":2}', ['this->value' => 2]],
+			'Array value with quotes Param not replaced' => ['{"value":"$this->value$"}', false, '{"value":"$this->value$"}', []],
+			'Array value with quotes Param replaced' => ['{"value":"$this->value$"}', false, '{"value":"toto"}', ['this->value' => 'toto']],
 		];
 	}
 

--- a/tests/php-unit-tests/ActionWebhookTest.php
+++ b/tests/php-unit-tests/ActionWebhookTest.php
@@ -111,6 +111,9 @@ class ActionWebhookTest extends ItopDataTestCase
 
 			'Array quotes in json Param not replaced' => ['{"value":"$this->value$"}', false, '{"value":"$this->value$"}', []],
 			'Array quotes in json Param replaced' => ['{"value":"$this->value$"}', false, '{"value":"toto"}', ['this->value' => 'toto']],
+
+			'Array int value in json Param not replaced' => ['{"value":$this->value$}', true],
+			'Array int value in json Param replaced' => ['{"value":$this->value$}', false, '{"value":2}', ['this->value' => 2]],
 		];
 	}
 

--- a/tests/php-unit-tests/ActionWebhookTest.php
+++ b/tests/php-unit-tests/ActionWebhookTest.php
@@ -1,27 +1,19 @@
 <?php
 /*
- * Copyright (C) 2023 Combodo SARL
- * This file is part of iTop.
- * iTop is free software; you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- * iTop is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- * You should have received a copy of the GNU Affero General Public License
+ * @copyright   Copyright (C) 2010-2023 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
  */
 
 namespace Combodo\iTop\Core\Test;
 
+use ActioniTopWebhook;
+use ActionWebhook;
+use Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException;
 use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use EventNotification;
+use RemoteApplicationType;
 use RemoteiTopConnection;
 use RemoteiTopConnectionToken;
-use RemoteApplicationType;
-use ActioniTopWebhook;
-use EventNotification;
-use MetaModel;
 
 
 /**
@@ -49,18 +41,18 @@ class ActionWebhookTest extends ItopDataTestCase
 		$oRemoteApplication->Set('auth_user', 'administrator');
 		$oRemoteApplication->Set('auth_pwd', 'Adm1nistrator++!!');
 		$oRemoteApplication->DBWrite();
-		
+
 		$oAction = new ActioniTopWebhook();
 		$oAction->Set('remoteapplicationconnection_id', $oRemoteApplication->GetKey());
 		$oAction->Set('test_remoteapplicationconnection_id', $oRemoteApplication->GetKey());
 		$oAction->Set('name', 'test');
 		$oAction->DBWrite();
-		
+
 		$oLog = new EventNotification();
-		
+
 		$aHeaders = $this->InvokeNonPublicMethod(get_class($oAction), 'PrepareHeaders', $oAction, [[], &$oLog]);
 		$this->assertEquals(['Content-type: application/json', 'Authorization: Basic YWRtaW5pc3RyYXRvcjpBZG0xbmlzdHJhdG9yKyshIQ=='], $aHeaders);
-		
+
 	}
 
 	public function testPrepareHeaderWithToken()
@@ -68,7 +60,7 @@ class ActionWebhookTest extends ItopDataTestCase
 		$oRemoteApplicationType = new RemoteApplicationType();
 		$oRemoteApplicationType->Set('name', 'iTop');
 		$oRemoteApplicationType->DBWrite();
-		
+
 		// iTop connexion via a token
 		$oRemoteApplicationToken = new RemoteiTopConnectionToken();
 		$oRemoteApplicationToken->Set('name', 'Test iTop');
@@ -76,17 +68,79 @@ class ActionWebhookTest extends ItopDataTestCase
 		$oRemoteApplicationToken->Set('url', 'https://www.combodo.com');
 		$oRemoteApplicationToken->Set('token', 'HAhq2Zfyr24ge!/jqsdf)sCf45A');
 		$oRemoteApplicationToken->DBWrite();
-		
+
 		$oAction = new ActioniTopWebhook();
 		$oAction->Set('remoteapplicationconnection_id', $oRemoteApplicationToken->GetKey());
 		$oAction->Set('test_remoteapplicationconnection_id', $oRemoteApplicationToken->GetKey());
 		$oAction->Set('name', 'test2');
 		$oAction->DBWrite();
-		
+
 		$oLog = new EventNotification();
-		
+
 		$aHeaders = $this->InvokeNonPublicMethod(get_class($oAction), 'PrepareHeaders', $oAction, [[], &$oLog]);
 		$this->assertEquals(['Content-type: application/json', 'Auth-Token: HAhq2Zfyr24ge!/jqsdf)sCf45A'], $aHeaders);
-		
+
+	}
+
+	/**
+	 * @dataProvider ApplyParamsToJsonProvider
+	 */
+	public function testApplyParamsToJson($json, bool $bExpectException, $expected = null, array $aContextArgs = [])
+	{
+		if ($bExpectException) {
+			$this->expectException(WebhookInvalidJsonValueException::class);
+		}
+
+		$oActionWebhook = new ActionWebhook();
+		$result = $this->InvokeNonPublicMethod(ActionWebhook::class, 'ApplyParamsToJson', $oActionWebhook,
+			[$aContextArgs, $json]);
+
+		if (false === $bExpectException) {
+			$this->assertSame($expected, $result);
+		}
+	}
+
+	public function ApplyParamsToJsonProvider(): array
+	{
+		return [
+			'String Param not replaced' => ['$this->value$', true],
+			'String Param replaced' => ['$this->value$', false, '"toto"', ['this->value' => '"toto"']],
+
+			'Array quotes in value Param not replaced' => ['{"value":$this->value$}', true],
+			'Array quotes in value Param replaced' => ['{"value":$this->value$}', false, '{"value":"toto"}', ['this->value' => '"toto"']],
+
+			'Array quotes in json Param not replaced' => ['{"value":"$this->value$"}', false, '{"value":"$this->value$"}', []],
+			'Array quotes in json Param replaced' => ['{"value":"$this->value$"}', false, '{"value":"toto"}', ['this->value' => 'toto']],
+		];
+	}
+
+	/**
+	 * @dataProvider GetContentTypeProvider
+	 */
+	public function testGetContentType($sInput, $expectedReturnedContentType)
+	{
+		$aHeaders = [$sInput];
+
+		$oActionWebhook = new ActionWebhook();
+		$result = $this->InvokeNonPublicMethod(ActionWebhook::class, 'GetContentType', $oActionWebhook,
+			[$aHeaders]);
+
+		$this->assertSame($expectedReturnedContentType, $result);
+	}
+
+	public function GetContentTypeProvider()
+	{
+		return [
+			'null' => [null, null],
+			'empty string' => ['', null],
+
+			'typo in header' => ['ContentTypo:application/json', null],
+
+			'correct header JSON' => ['Content-type:application/json', 'application/json'],
+			'correct header JSON with spaces and tab' => ['Content-type   :		   application/json', 'application/json'],
+
+			'header no value' => ['Content-type:', null],
+			'header value only spaces and tab' => ['Content-type:   	    ', null],
+		];
 	}
 }

--- a/tests/php-unit-tests/_ActionWebhookTest.php
+++ b/tests/php-unit-tests/_ActionWebhookTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * @copyright   Copyright (C) 2010-2023 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\Test\UnitTest\Core;
+
+use Combodo\iTop\Core\Notification\Action\_ActionWebhook;
+use Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException;
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+
+class _ActionWebhookTest extends ItopTestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		// no datamodel loaded so we need to include module file manually
+		$this->RequireOnceItopFile('env-production/combodo-webhook-integration/src/Core/Notification/Action/_ActionWebhook.php');
+		$this->RequireOnceItopFile('env-production/combodo-webhook-integration/src/Core/Notification/Action/Webhook/Exception/WebhookInvalidJsonValueException.php');
+	}
+
+	/**
+	 * @param ?string|boolean $sJson
+	 * @param false|array $expected
+	 *
+	 * @return void
+	 *
+	 * @dataProvider IsJsonValidProvider
+	 */
+	public function testIsJsonValid($json, $bExpectException, $expected = null) {
+		if ($bExpectException) {
+			$this->expectException(WebhookInvalidJsonValueException::class);
+		}
+		$result = _ActionWebhook::JsonDecodeWithError($json);
+
+		if (false === $bExpectException) {
+			$this->assertSame($expected, $result);
+		}
+	}
+
+	public function IsJsonValidProvider() {
+		return [
+			'null' => [null, true],
+
+			'false' => [false, true],
+			'true' => [true, false, 1],
+
+			'null string' => ['null', false, null],
+			'false string' => ['false', false, false],
+			'true string' => ['true', false, true],
+			'string without quotes' => ['foobar', true],
+			'string with quotes' => ['"foobar"', false, 'foobar'],
+
+			'simple array' => ['{"foo":"bar"}', false, ['foo' => 'bar']],
+			'invalid array' => ['{foo:bar}', true],
+		];
+	}
+}

--- a/tests/php-unit-tests/_ActionWebhookTest.php
+++ b/tests/php-unit-tests/_ActionWebhookTest.php
@@ -40,17 +40,19 @@ class _ActionWebhookTest extends ItopTestCase {
 
 	public function IsJsonValidProvider() {
 		return [
+			// non string values should exit right away
 			'null' => [null, true],
-
 			'false' => [false, true],
-			'true' => [true, false, 1],
+			'true' => [true, true],
 
+			// simple strings
 			'null string' => ['null', false, null],
 			'false string' => ['false', false, false],
 			'true string' => ['true', false, true],
 			'string without quotes' => ['foobar', true],
 			'string with quotes' => ['"foobar"', false, 'foobar'],
 
+			// strings containing json objects
 			'simple array' => ['{"foo":"bar"}', false, ['foo' => 'bar']],
 			'integer array' => ['{"foo":123}', false, ['foo' => 123]],
 			'invalid array' => ['{foo:bar}', true],

--- a/tests/php-unit-tests/_ActionWebhookTest.php
+++ b/tests/php-unit-tests/_ActionWebhookTest.php
@@ -52,6 +52,7 @@ class _ActionWebhookTest extends ItopTestCase {
 			'string with quotes' => ['"foobar"', false, 'foobar'],
 
 			'simple array' => ['{"foo":"bar"}', false, ['foo' => 'bar']],
+			'integer array' => ['{"foo":123}', false, ['foo' => 123]],
 			'invalid array' => ['{foo:bar}', true],
 		];
 	}


### PR DESCRIPTION
- we were only accepting PHP arrays as valid decoded value
- the validity check was made before having placeholders replaced

Those are flaws we saw during the discussion that occurs in #16 thanks to Hipska !

In this PR are the modifications only related to this validation improvement.