### PR TITLE
N°7242 - Allow to mention new user IDs in Slack messages

### DIFF
--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -1648,7 +1648,8 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 			$sContent = str_replace($aResult[0][$iIdx], '<'.$aResult[1][$iIdx].'|'.$aResult[2][$iIdx].'>', $sContent);
 		}
 
-		// Replace user Ids
+		// Replace users and groups IDs to ensure they don't have HTML entities
+		// Note: As an input, only HTML entities IDs (eg. "&lt;@U123ABC&gt;") are supported as raw IDs (eg. "<@U123ABC>") will be considered unexpected tags and be removed by the `strip_tags()` above.
 		$sContent = preg_replace('/&lt;([!@].*?)&gt;/', '<$1>', $sContent);
 
 		return $sContent;

--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -1648,6 +1648,9 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 			$sContent = str_replace($aResult[0][$iIdx], '<'.$aResult[1][$iIdx].'|'.$aResult[2][$iIdx].'>', $sContent);
 		}
 
+		// Replace user Ids
+		$sContent = preg_replace('/&lt;([!@].*?)&gt;/', '<$1>', $sContent);
+
 		return $sContent;
 	}
 ]]>

--- a/tests/php-unit-tests/ActionSlackNotificationTest.php
+++ b/tests/php-unit-tests/ActionSlackNotificationTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * @copyright   Copyright (C) 2010-2023 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\Test\UnitTest\CombodoWebhookIntegration;
+
+use ActionSlackNotification;
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+
+
+class ActionSlackNotificationTest extends ItopDataTestCase
+{
+	/**
+	 * @dataProvider TransformHTMLToSlackMarkupProvider
+	 *
+	 * @param string $sInput
+	 * @param string $sExpected
+	 *
+	 * @return void
+	 */
+	public function testTransformHTMLToSlackMarkup(string $sInput, string $sExpected): void
+	{
+		$sTested = ActionSlackNotification::TransformHTMLToSlackMarkup($sInput);
+		$this->assertEquals($sExpected, $sTested, "HTML not transform to Slack Markup as expected");
+	}
+
+	public function TransformHTMLToSlackMarkupProvider(): array
+	{
+		return [
+			"Hyperlink" => [
+				"input" => <<<HTML
+<a href="https://github.com/Combodo/iTop" _target="blank">iTop Repository</a>
+HTML,
+				"expected" => "<https://github.com/Combodo/iTop|iTop Repository>",
+			],
+			"Mention old user ID with special chars encoded" => [
+				"input" => <<<HTML
+&lt;@Molkobain&gt;
+HTML,
+				"expected" => "<@Molkobain>",
+			],
+			"Mention new user ID with special chars encoded" => [
+				"input" => <<<HTML
+&lt;@U123456ABC&gt;
+HTML,
+				"expected" => "<@U123456ABC>",
+			],
+			"Mention new group ID with special chars encoded" => [
+				"input" => <<<HTML
+&lt;!SomeGroup&gt;
+HTML,
+				"expected" => "<!SomeGroup>",
+			],
+		];
+	}
+}


### PR DESCRIPTION
To mention a user in a Slack message, you should write in Markdown "... <@userID> ..."

However, for original user ID it also supports the HTML form "... &lt;@userID&gt; ...", but this doesn't work with new user IDs of the form UXXXX (they can be found in the user profile).

iTop webhooks store messages in HTML and convert them to Markdown, but it doesn't transform the UID syntax, so mentioning user for old users works, but not for recent users.

This patch makes the translation to fix this behavior.