### PR TITLE
N°8008 - Webhooks: Failed to update triggering object on process response callback

### DIFF
--- a/src/Core/Notification/Action/_ActionWebhook.php
+++ b/src/Core/Notification/Action/_ActionWebhook.php
@@ -163,18 +163,21 @@ abstract class _ActionWebhook extends ActionNotification
 			// Set default response handler if not already defined (this also custom ActionWebhook classes to define their own)
 			if ($oRequest->HasResponseHandler() === false) {
                 $aHandlerParams = [
-                    'oTriggeringObject' => [
-                        'class' => get_class($oTriggeringObject),
-                        'id' => $oTriggeringObject->GetKey(),
-                    ],
                     'oActionWebhook' => [
                         'class' => $sActionClass,
                         'id' => $this->GetKey(),
                     ],
                 ];
-                if (!$this->IsAsynchronous()) {
-                    $aHandlerParams['oObject'] =$oTriggeringObject;
+                
+                if ($this->IsAsynchronous()) {
+                    $aHandlerParams['oTriggeringObject'] = [
+                        'class' => get_class($oTriggeringObject),
+                        'id' => $oTriggeringObject->GetKey(),
+                    ];
+                } else {
+                    $aHandlerParams['oObject'] = $oTriggeringObject;
                 }
+                
 				$oRequest->SetResponseHandlerName($sActionClass.'::ExecuteResponseHandler')
 				->SetResponseHandlerParams($aHandlerParams);
 			}

--- a/src/Core/Notification/Action/_ActionWebhook.php
+++ b/src/Core/Notification/Action/_ActionWebhook.php
@@ -172,7 +172,7 @@ abstract class _ActionWebhook extends ActionNotification
                         'id' => $oTriggeringObject->GetKey(),
                     ];
                 } else {
-                    $aHandlerParams['oObject'] = $oTriggeringObject;
+                    $aHandlerParams['oTriggeringObject'] = $oTriggeringObject;
                 }
                 
 				$oRequest->SetResponseHandlerName($sActionClass.'::ExecuteResponseHandler')

--- a/src/Core/Notification/Action/_ActionWebhook.php
+++ b/src/Core/Notification/Action/_ActionWebhook.php
@@ -42,8 +42,12 @@ abstract class _ActionWebhook extends ActionNotification
 			]);
 			throw new Exception('Missing parameters in response handler. See error log for details.');
 		}
-
-		$oTriggeringObject = MetaModel::GetObject($aParams['oTriggeringObject']['class'], $aParams['oTriggeringObject']['id'], true, true);
+        $oTriggeringObject = null;
+        if (isset($aParams['oObject'])) {
+            $oTriggeringObject=  $aParams['oObject'] ;
+        } else {
+            $oTriggeringObject = MetaModel::GetObject($aParams['oTriggeringObject']['class'], $aParams['oTriggeringObject']['id'], true, true);
+        }
 		$oActionWebhook = MetaModel::GetObject($aParams['oActionWebhook']['class'], $aParams['oActionWebhook']['id'], true, true);
 
 		// Check if callback is on the object itself
@@ -158,17 +162,21 @@ abstract class _ActionWebhook extends ActionNotification
 
 			// Set default response handler if not already defined (this also custom ActionWebhook classes to define their own)
 			if ($oRequest->HasResponseHandler() === false) {
+                $aHandlerParams = [
+                    'oTriggeringObject' => [
+                        'class' => get_class($oTriggeringObject),
+                        'id' => $oTriggeringObject->GetKey(),
+                    ],
+                    'oActionWebhook' => [
+                        'class' => $sActionClass,
+                        'id' => $this->GetKey(),
+                    ],
+                ];
+                if (!$this->IsAsynchronous()) {
+                    $aHandlerParams['oObject'] =$oTriggeringObject;
+                }
 				$oRequest->SetResponseHandlerName($sActionClass.'::ExecuteResponseHandler')
-				->SetResponseHandlerParams([
-					'oTriggeringObject' => [
-						'class' => get_class($oTriggeringObject),
-						'id' => $oTriggeringObject->GetKey(),
-					],
-					'oActionWebhook' => [
-						'class' => $sActionClass,
-						'id' => $this->GetKey(),
-					],
-				]);
+				->SetResponseHandlerParams($aHandlerParams);
 			}
 
 			// Errors during preparation

--- a/src/Core/Notification/Action/_ActionWebhook.php
+++ b/src/Core/Notification/Action/_ActionWebhook.php
@@ -42,12 +42,9 @@ abstract class _ActionWebhook extends ActionNotification
 			]);
 			throw new Exception('Missing parameters in response handler. See error log for details.');
 		}
-        $oTriggeringObject = null;
-        if (isset($aParams['oObject'])) {
-            $oTriggeringObject=  $aParams['oObject'] ;
-        } else {
-            $oTriggeringObject = MetaModel::GetObject($aParams['oTriggeringObject']['class'], $aParams['oTriggeringObject']['id'], true, true);
-        }
+        $oTriggeringObject = is_object($aParams['oTriggeringObject']) ?
+                            $aParams['oTriggeringObject'] :
+                            MetaModel::GetObject($aParams['oTriggeringObject']['class'], $aParams['oTriggeringObject']['id'], true, true);
 		$oActionWebhook = MetaModel::GetObject($aParams['oActionWebhook']['class'], $aParams['oActionWebhook']['id'], true, true);
 
 		// Check if callback is on the object itself

--- a/src/Service/WebRequestSender.php
+++ b/src/Service/WebRequestSender.php
@@ -58,7 +58,12 @@ class WebRequestSender
 
 	/** @var null|\Combodo\iTop\Service\WebRequestSender $oInstance */
 	public static $oInstance = null;
+	private static bool $mockDoPostRequest = false;
 
+	public static function SetMockDoPostRequest(bool $mockDoPostRequest): void
+	{
+		static::$mockDoPostRequest = $mockDoPostRequest;
+	}
 	/**
 	 * Return the singleton instance for this class
 	 *
@@ -120,7 +125,7 @@ class WebRequestSender
 		try
 		{
 			$aResponseHeaders = array();
-			$sResponse = utils::DoPostRequest($oRequest->GetURL(), array(), null, $aResponseHeaders, $oRequest->GetOptions());
+			$sResponse = $this->DoPostRequest($oRequest->GetURL(), array(), null, $aResponseHeaders, $oRequest->GetOptions());
 
 			$oResponse = new WebResponse();
 			$oResponse->SetHeaders($aResponseHeaders)
@@ -190,5 +195,14 @@ class WebRequestSender
 			'sender_status' => static::ENUM_SEND_STATE_PENDING,
 			'response' => null,
 		);
+	}
+
+	private function DoPostRequest($sUrl, $aData, $sOptionnalHeaders = null, &$aResponseHeaders = null, $aCurlOptions = array())
+	{
+		if (static::$mockDoPostRequest) {
+			return '';
+		} else {
+			return utils::DoPostRequest($sUrl, $aData, $sOptionnalHeaders, $aResponseHeaders, $aCurlOptions);
+		}
 	}
 }

--- a/tests/php-unit-tests/ActionWebhookTest.php
+++ b/tests/php-unit-tests/ActionWebhookTest.php
@@ -65,6 +65,7 @@ class ActionWebhookTest extends ItopDataTestCase
 
 	public function testOnObjectCreateCallbackShouldBeAllowedToModifyTriggeringObject()
 	{
+		WebRequestSender::SetMockDoPostRequest(true);
 		$oObject = MetaModel::NewObject('Person', ['first_name' => 'John', 'name' => 'Doe', ]);
 
 		$iTrigger = $this->GivenTriggerOnObjectCreate($oObject);

--- a/tests/php-unit-tests/ActionWebhookTest.php
+++ b/tests/php-unit-tests/ActionWebhookTest.php
@@ -21,6 +21,7 @@ use RemoteiTopConnection;
 use RemoteiTopConnectionToken;
 use TriggerOnObjectCreate;
 use TriggerOnObjectUpdate;
+use utils;
 
 
 /**
@@ -51,10 +52,9 @@ class ActionWebhookTest extends ItopDataTestCase
 		$this->GivenWebhookActionInvokingCallbackOnResponse($iTrigger, function (DBObject $oTriggeringObject, WebResponse $oWebReponse, ActionWebhook $oActionWebhook): void
 		{
 			$oTriggeringObject->Set('name', 'NameByCallBack');
-			$oTriggeringObject->DBUpdate();
 		});
 
-		$this->WhenObjectIsUpdated($oObject);
+		$this->WhenObjectIsUpdatedOnOtherFieldThanName($oObject);
 
 		$this->assertEquals('NameByCallBack', $oObject->Get('name'), 'The callback should have modified the object in memory');
 		$oObject->Reload();
@@ -73,7 +73,7 @@ class ActionWebhookTest extends ItopDataTestCase
 			$oTriggeringObject->DBUpdate();
 		});
 
-		$this->WhenObjectIsCreated($oObject);
+		$this->WhenObjectIsCreatedWithoutName($oObject);
 
 		$this->assertEquals('NameByCallBack', $oObject->Get('name'), 'The callback should have modified the object in memory');
 		$oObject->Reload();
@@ -260,7 +260,7 @@ class ActionWebhookTest extends ItopDataTestCase
 		$iRemoteApplicationConnection= $this->GivenObjectInDB('RemoteApplicationConnection', [
 			'name' => 'Test localhost',
 			'remoteapplicationtype_id' => $iRemoteApplicationType,
-			'url' => 'http://localhost',
+			'url' => '127.0.0.1',
 		]);
 
 		$this->GivenObjectInDB('ActionWebhook', [
@@ -291,13 +291,13 @@ class ActionWebhookTest extends ItopDataTestCase
 		]);
 	}
 
-	public function WhenObjectIsUpdated(DBObject $oDBObject)
+	public function WhenObjectIsUpdatedOnOtherFieldThanName(DBObject $oDBObject)
 	{
 		$oDBObject->Set('first_name', 'François');
 		$oDBObject->DBUpdate();
 	}
 
-	public function WhenObjectIsCreated(DBObject $oDBObject)
+	public function WhenObjectIsCreatedWithoutName(DBObject $oDBObject)
 	{
 		$oDBObject->Set('org_id', $this->GetTestOrgId());
 		$oDBObject->DBInsert();

--- a/tests/php-unit-tests/ActionWebhookTest.php
+++ b/tests/php-unit-tests/ActionWebhookTest.php
@@ -8,13 +8,19 @@ namespace Combodo\iTop\Core\Test;
 
 use ActioniTopWebhook;
 use ActionWebhook;
+use Closure;
 use Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException;
+use Combodo\iTop\Core\WebResponse;
 use Combodo\iTop\Oauth2Client\Service\Oauth2Service;
 use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use DBObject;
 use EventNotification;
+use MetaModel;
 use RemoteApplicationType;
 use RemoteiTopConnection;
 use RemoteiTopConnectionToken;
+use TriggerOnObjectCreate;
+use TriggerOnObjectUpdate;
 
 
 /**
@@ -24,12 +30,54 @@ use RemoteiTopConnectionToken;
  */
 class ActionWebhookTest extends ItopDataTestCase
 {
+	const CREATE_TEST_ORG = true;
+	static Closure $oCallBackWebhook;
 	protected function setUp(): void {
 		parent::setUp();
 	}
 
 	protected function tearDown(): void {
 		parent::tearDown();
+	}
+
+	public function testOnObjectUpdateCallbackShouldBeAllowedToModifyTriggeringObject()
+	{
+		$iPerson = $this->GivenObjectInDB('Person', ['first_name' => 'John', 'name' => 'Doe']);
+		$oObject = MetaModel::GetObject('Person', $iPerson);
+
+		$iTrigger = $this->GivenTriggerOnObjectUpdate($oObject);
+
+
+		$this->GivenWebhookActionInvokingCallbackOnResponse($iTrigger, function (DBObject $oTriggeringObject, WebResponse $oWebReponse, ActionWebhook $oActionWebhook): void
+		{
+			$oTriggeringObject->Set('name', 'NameByCallBack');
+			$oTriggeringObject->DBUpdate();
+		});
+
+		$this->WhenObjectIsUpdated($oObject);
+
+		$this->assertEquals('NameByCallBack', $oObject->Get('name'), 'The callback should have modified the object in memory');
+		$oObject->Reload();
+		$this->assertEquals('NameByCallBack', $oObject->Get('name'), 'The callback should have modified the object on the database');
+	}
+
+	public function testOnObjectCreateCallbackShouldBeAllowedToModifyTriggeringObject()
+	{
+		$oObject = MetaModel::NewObject('Person', ['first_name' => 'John', 'name' => 'Doe', ]);
+
+		$iTrigger = $this->GivenTriggerOnObjectCreate($oObject);
+
+		$this->GivenWebhookActionInvokingCallbackOnResponse($iTrigger, function (DBObject $oTriggeringObject, WebResponse $oWebReponse, ActionWebhook $oActionWebhook): void
+		{
+			$oTriggeringObject->Set('name', 'NameByCallBack');
+			$oTriggeringObject->DBUpdate();
+		});
+
+		$this->WhenObjectIsCreated($oObject);
+
+		$this->assertEquals('NameByCallBack', $oObject->Get('name'), 'The callback should have modified the object in memory');
+		$oObject->Reload();
+		$this->assertEquals('NameByCallBack', $oObject->Get('name'), 'The callback should have modified the object on the database');
 	}
 
 	public function testPrepareHeaderWithUserAndPassword()
@@ -195,5 +243,63 @@ class ActionWebhookTest extends ItopDataTestCase
 			'header no value' => ['Content-type:', null],
 			'header value only spaces and tab' => ['Content-type:   	    ', null],
 		];
+	}
+
+	public static function CallBackWebhook(DBObject $oTriggeringObject, WebResponse $oWebReponse, ActionWebhook $oActionWebhook): void
+	{
+		call_user_func(static::$oCallBackWebhook, $oTriggeringObject, $oWebReponse, $oActionWebhook);
+	}
+
+	public function GivenWebhookActionInvokingCallbackOnResponse(int $iTrigger, Closure $oCallBack): void
+	{
+		static::$oCallBackWebhook = $oCallBack;
+		$iRemoteApplicationType = $this->GivenObjectInDB('RemoteApplicationType', [
+			'name' => 'My connection type',
+		]);
+
+		$iRemoteApplicationConnection= $this->GivenObjectInDB('RemoteApplicationConnection', [
+			'name' => 'Test localhost',
+			'remoteapplicationtype_id' => $iRemoteApplicationType,
+			'url' => 'http://localhost',
+		]);
+
+		$this->GivenObjectInDB('ActionWebhook', [
+			'asynchronous' => 'no',
+			'name' => 'Test',
+			'status' => 'test',
+			'remoteapplicationconnection_id' => $iRemoteApplicationConnection,
+			'test_remoteapplicationconnection_id' => $iRemoteApplicationConnection,
+			'process_response_callback' => __CLASS__.'::CallBackWebhook',
+			'payload' => '{}',
+			'trigger_list' => ['trigger_id:' . $iTrigger],
+		]);
+	}
+
+	public function GivenTriggerOnObjectUpdate(DBObject $object): int
+	{
+		return $this->GivenObjectInDB(TriggerOnObjectUpdate::class, [
+			'description'  => 'My description',
+			'target_class' => get_class($object)
+		]);
+	}
+
+	public function GivenTriggerOnObjectCreate(DBObject $object): int
+	{
+		return $this->GivenObjectInDB(TriggerOnObjectCreate::class, [
+			'description'  => 'My description',
+			'target_class' => get_class($object)
+		]);
+	}
+
+	public function WhenObjectIsUpdated(DBObject $oDBObject)
+	{
+		$oDBObject->Set('first_name', 'François');
+		$oDBObject->DBUpdate();
+	}
+
+	public function WhenObjectIsCreated(DBObject $oDBObject)
+	{
+		$oDBObject->Set('org_id', $this->GetTestOrgId());
+		$oDBObject->DBInsert();
 	}
 }

--- a/tests/php-unit-tests/ActionWebhookTest.php
+++ b/tests/php-unit-tests/ActionWebhookTest.php
@@ -12,6 +12,7 @@ use Closure;
 use Combodo\iTop\Core\Notification\Action\Webhook\Exception\WebhookInvalidJsonValueException;
 use Combodo\iTop\Core\WebResponse;
 use Combodo\iTop\Oauth2Client\Service\Oauth2Service;
+use Combodo\iTop\Service\WebRequestSender;
 use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
 use DBObject;
 use EventNotification;
@@ -43,6 +44,7 @@ class ActionWebhookTest extends ItopDataTestCase
 
 	public function testOnObjectUpdateCallbackShouldBeAllowedToModifyTriggeringObject()
 	{
+		WebRequestSender::SetMockDoPostRequest(true);
 		$iPerson = $this->GivenObjectInDB('Person', ['first_name' => 'John', 'name' => 'Doe']);
 		$oObject = MetaModel::GetObject('Person', $iPerson);
 
@@ -73,7 +75,7 @@ class ActionWebhookTest extends ItopDataTestCase
 			$oTriggeringObject->DBUpdate();
 		});
 
-		$this->WhenObjectIsCreatedWithoutName($oObject);
+		$this->WhenObjectIsInsertedWithoutNameChange($oObject);
 
 		$this->assertEquals('NameByCallBack', $oObject->Get('name'), 'The callback should have modified the object in memory');
 		$oObject->Reload();

--- a/tests/php-unit-tests/ActionWebhookTest.php
+++ b/tests/php-unit-tests/ActionWebhookTest.php
@@ -260,7 +260,7 @@ class ActionWebhookTest extends ItopDataTestCase
 		$iRemoteApplicationConnection= $this->GivenObjectInDB('RemoteApplicationConnection', [
 			'name' => 'Test localhost',
 			'remoteapplicationtype_id' => $iRemoteApplicationType,
-			'url' => '127.0.0.1',
+			'url' => utils::GetAbsoluteUrlAppRoot(),
 		]);
 
 		$this->GivenObjectInDB('ActionWebhook', [

--- a/tests/php-unit-tests/ActionWebhookTest.php
+++ b/tests/php-unit-tests/ActionWebhookTest.php
@@ -297,7 +297,7 @@ class ActionWebhookTest extends ItopDataTestCase
 		$oDBObject->DBUpdate();
 	}
 
-	public function WhenObjectIsCreatedWithoutName(DBObject $oDBObject)
+	public function WhenObjectIsInsertedWithoutNameChange(DBObject $oDBObject)
 	{
 		$oDBObject->Set('org_id', $this->GetTestOrgId());
 		$oDBObject->DBInsert();


### PR DESCRIPTION

If the webhook is in synchronous mode
The callback method should not call BDUpdate(). The update is done at the end of the whole process.