### PR TITLE
N°8402 - fix(ActionSlackNotification): Improve TransformHTMLToSlackMarkup with…

### DIFF
--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -1749,26 +1749,22 @@ protected function ApplyParamsToJson(array $aContextArgs, string $sInputAsJson)
 		}
 
 		$aReplacementsMatrix = array(
-			array( array('<br />', '<br/>', '<br>'), "\n" ),
-			array( array('<h1>', '</h1>'), array('*', '*') ),
-			array( array('<h2>', '</h2>'), array('*', '*') ),
-			array( array('<h3>', '</h3>'), array('*', '*') ),
-			array( array('<strong>', '</strong>'), array('*', '*') ),
-			array( array('<b>', '</b>'), array('*', '*') ),
-			array( array('<em>', '</em>'), array('_', '_') ),
-			array( array('<i>', '</i>'), array('_', '_') ),
-			array( array('<del>', '</del>'), array('~', '~') ),
-			array( array('<s>', '</s>'), array('~', '~') ),
-			array( array('<li>', '</li>'), array('• ', '') ),
-			array( array('<code>', '</code>'), array('`', '`') ),
-			array( array('<pre>', '</pre>'), array('```', '```') ),
+			[ '#<br(\s*/)?>#i', "\n" ],
+			[ ['#<p>#i', '#</p>#i'], ['', "\n"] ],
+			[ ['#<h[1,2,3]>#i', '#</h[1,2,3]>#i'], ['*', "*\n"] ],
+			[ ['#<(strong|b)>#i', '#</(strong|b)>#i'], '*' ],
+			[ ['#<(em|i)>#i', '#</(em|i)>#i'], '_' ],
+			[ ['#<(del|s)>#i', '#</(del|s)>#i'], '~' ],
+			[ ['#<li>#i', '#</li>#i'], ['• ', "\n"] ],
+			[ ['#<pre>(<code[^>]*>)?#i', '#(</code>)?</pre>#i'], ['```', "```\n"] ],
+			[ ['#<(mark[^>]*|code)>#i', '#</(mark|code)>#i'], '`' ],
 		);
 
 		// Replace HTML tags (list must contain at least tags from the $aReplacementsMatrix)
-		$sContent = strip_tags($sContent, '<h1><h2><h3><br><strong><b><em><i><del><s><li><code><pre><a>');
+		$sContent = strip_tags($sContent, '<br><p><h1><h2><h3><strong><b><em><i><del><s><li><pre><code><mark><a>');
 		foreach($aReplacementsMatrix as $aReplacements)
 		{
-			$sContent = str_replace($aReplacements[0], $aReplacements[1], $sContent);
+			$sContent = preg_replace($aReplacements[0], $aReplacements[1], $sContent);
 		}
 
 		// Replace hyperlinks

--- a/module.combodo-webhook-integration.php
+++ b/module.combodo-webhook-integration.php
@@ -5,7 +5,7 @@
 //
 //
 SetupWebPage::AddModule(__FILE__, // Path to the current file, all other file names are relative to the directory containing this file
-	'combodo-webhook-integration/1.4.1', array(
+	'combodo-webhook-integration/1.4.2', array(
 		// Identification
 		//
 		'label' => 'Webhook integrations',

--- a/tests/php-unit-tests/ActionSlackNotificationTest.php
+++ b/tests/php-unit-tests/ActionSlackNotificationTest.php
@@ -55,9 +55,9 @@ HTML,
 			],
 			"Large text with different tags" => [
 				"input" => <<<HTML
-<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><p><strong>Strong Text</strong><br><strong>Bold Text</strong><br><i>Emphasized Text</i><br><i>Italic Text</i><br><s>Deleted Text</s><br><s>Strikethrough Text</s><br> </p><ul><li>List Item 1</li><li>List Item 2</li></ul><p><code>Inline Code</code><br> </p><pre>Block of Code\r\nLine 1\r\nLine 2\r\n</pre>
+<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><p><strong>Strong Text</strong><br><b>Bold Text</b><br><em>Emphasized Text</em><br><i>Italic Text</i><br><del>Deleted Text</del><br><s>Strikethrough Text</s><br><mark class="marker-yellow">Marked Text</mark><br><code>Inline Code</code></p><ul><li>List Item 1</li><li>List Item 2</li></ul><pre><code class="language-plaintext">Block of Code\r\nLine 1\r\nLine 2\r\n</code></pre>
 HTML,
-				"expected" => "*Heading 1*\n*Heading 2*\n*Heading 3*\n*Strong Text*\n*Bold Text*\n_Emphasized Text_\n_Italic Text_\n~Deleted Text~\n~Strikethrough Text~\n \n• List Item 1\n• List Item 2\n`Inline Code`\n \n```Block of Code\r\nLine 1\r\nLine 2\r\n```\n",
+				"expected" => "*Heading 1*\n*Heading 2*\n*Heading 3*\n*Strong Text*\n*Bold Text*\n_Emphasized Text_\n_Italic Text_\n~Deleted Text~\n~Strikethrough Text~\n`Marked Text`\n`Inline Code`\n• List Item 1\n• List Item 2\n```Block of Code\r\nLine 1\r\nLine 2\r\n```\n",
 			],			
 		];
 	}

--- a/tests/php-unit-tests/ActionSlackNotificationTest.php
+++ b/tests/php-unit-tests/ActionSlackNotificationTest.php
@@ -53,12 +53,30 @@ HTML,
 HTML,
 				"expected" => "<!SomeGroup>",
 			],
+			"Simple p tags on different lines" => [
+				"input" => <<<HTML
+<p>hello</p><p>hi</p>
+HTML,
+				"expected" => "hello\nhi\n",
+			],
+			"Different tags on different lines" => [
+				"input" => <<<HTML
+<h2>hello</h2><p><strong>hi</strong></p>
+HTML,
+				"expected" => "*hello*\n*hi*\n",
+			],
+			"Nested tags" => [
+				"input" => <<<HTML
+<p><strong>I'm bold and</strong></p><p><i><strong>I'm bold and italic</strong></i></p>
+HTML,
+				"expected" => "*I'm bold and*\n_*I'm bold and italic*_\n",
+			],
 			"Large text with different tags" => [
 				"input" => <<<HTML
 <h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><p><strong>Strong Text</strong><br><b>Bold Text</b><br><em>Emphasized Text</em><br><i>Italic Text</i><br><del>Deleted Text</del><br><s>Strikethrough Text</s><br><mark class="marker-yellow">Marked Text</mark><br><code>Inline Code</code></p><ul><li>List Item 1</li><li>List Item 2</li></ul><pre><code class="language-plaintext">Block of Code\r\nLine 1\r\nLine 2\r\n</code></pre>
 HTML,
 				"expected" => "*Heading 1*\n*Heading 2*\n*Heading 3*\n*Strong Text*\n*Bold Text*\n_Emphasized Text_\n_Italic Text_\n~Deleted Text~\n~Strikethrough Text~\n`Marked Text`\n`Inline Code`\n• List Item 1\n• List Item 2\n```Block of Code\r\nLine 1\r\nLine 2\r\n```\n",
-			],			
+			],
 		];
 	}
 }


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Bug fix

## Symptom
The CKEditor in iTop 3.2 doesn't add newlines anymore after headers and paragraphs in the underlaying HTML code.

## Reproduction procedure
1. On iTop 3.2.1 <!-- Put complete iTop version (eg. 3.1.0-2) -->
2. Make sure there is a Slack notification for a new public log entry
3. Add a new public comment on a ticket. Make sure to include multiple paragraphs and/or headers.
4. Observe the notification on Slack being malformed due to no newlines in the markdown text.

## Cause
The updated CKE does not include newlines between html tags anymore.
```diff
- <p>Paragraph 1</p>
- <p>Paragraph 2</p>
+ <p>Paragraph 1</p><p>Paragraph 2</p>
```

This results in the following message markdown on Slack:
```markdown
Paragraph 1Paragraph 2
```

## Proposed solution

Add newline (`\n`) after paragraphs (`p`), headers (`h1`, `h2`, `h3`), list items (`li`) and code blocks.

Similar to what has been done in 7150630 for MS Teams.


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] Would a unit test be relevant and have I added it?
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?
