### PR TITLE
Fix webhook with prepare_payload_callback

### DIFF
--- a/datamodel.combodo-webhook-integration.xml
+++ b/datamodel.combodo-webhook-integration.xml
@@ -854,7 +854,7 @@
 
 			$oCallBack = new Combodo\iTop\Service\CallbackService($sCallbackFQCN);
 			$oCallBack->CheckCallbackSignature(get_class($oTriggeringObject), ['array', EventNotification::class, ActionWebhook::class]);
-			$oCallBack->Invoke($oTriggeringObject, [$aContextArgs, $oLog, $this]);
+			$payload = $oCallBack->Invoke($oTriggeringObject, [$aContextArgs, $oLog, $this]);
 		}
 
 		return $payload;


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | -
| Type of change?                                               | Bug fix


## Symptom (bug)

Since we upgraded to itop 3.2.2 our webhooks failed to run.
Our webhook use a payload call back we wrote and our webhook service told told us that there was no payload.

## Reproduction procedure (bug)

On iTop 3.2.2
Create a webhook and use a callback to create the payload instead of a JSON.
The payload is empty on calls.

## Cause (bug)

See 1 line fix

## Proposed solution (bug and enhancement)

See 1 line fix

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have tested all changes I made on an iTop instance
- [ ] Would a unit test be relevant and have I added it?
- [ ] Is the PR clear and detailed enough so anyone can understand without digging in the code?

