### PR TITLE
N°8952 - Correct variable naming and syntax errors in webhook actions

### DIFF
--- a/src/Core/Notification/Action/_ActionWebhook.php
+++ b/src/Core/Notification/Action/_ActionWebhook.php
@@ -173,9 +173,9 @@ abstract class _ActionWebhook extends ActionNotification
 			}
 
 			// Errors during preparation
-			if (!empty($this->m_aWebrequestErrors))
+			if (!empty($this->aRequestErrors))
 			{
-				return 'Errors: '.implode(', ', $this->m_aWebrequestErrors);
+				return 'Errors: '.implode(', ', $this->aRequestErrors);
 			}
 
 			if ($this->IsBeingTested() && empty($oRequest->GetURL()))
@@ -197,7 +197,7 @@ abstract class _ActionWebhook extends ActionNotification
 				case WebRequestSender::ENUM_SEND_STATE_PENDING:
 					return 'Pending';
 
-				case WebRequestSender::ENUM_SEND_STATE_ERROR;
+				case WebRequestSender::ENUM_SEND_STATE_ERROR:
 					return 'Errors: '.implode(', ', $this->aRequestErrors);
 			}
 		}


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | <!-- Put the URL -->
| Type of change?                                               | Bug fix

## Symptom (bug) / Objective (enhancement)
<!--
Bug: The webhook action code referenced a non-existent property (`$this->m_aWebrequestErrors`) and had a syntax error in a switch statement. This caused PHP runtime notices and could prevent the module from working correctly.
-->

- In `src/Core/Notification/Action/_ActionWebhook.php`, the code referenced `$this->m_aWebrequestErrors` instead of the correct `$this->aRequestErrors`, causing runtime errors.
- The same file had a syntax error: `case WebRequestSender::ENUM_SEND_STATE_ERROR;` (semicolon instead of colon).
- In `tests/php-unit-tests/_ActionWebhookTest.php`, unused imports (`Exception`, `ReflectionException`) were present.

## Reproduction procedure (bug)
<!--
1. On iTop x.y.z <!-- Put complete iTop version (eg. 3.1.0-2) -->
2. With module version x.y.z <!-- Put complete module version (eg. 1.2.1) -->
3. With PHP x.y.z <!-- Put complete PHP version (eg. 8.1.24) -->
4. Trigger a webhook action that results in an error (e.g., invalid callback signature).
5. Observe PHP notices about undefined property or syntax errors in logs.
-->

1. On iTop 3.x.x
2. With module version 1.x.x
3. With PHP 7.4+ or 8.x
4. Trigger a webhook action that should log errors (e.g., misconfigured callback).
5. See PHP notice: "Undefined property: ...m_aWebrequestErrors"
6. See parse error if the switch case is hit.

## Cause (bug)
<!--
The code referenced a property name that does not exist (`m_aWebrequestErrors` instead of `aRequestErrors`). The switch statement used a semicolon instead of a colon, causing a parse error.
-->

- Typo in property name: should be `$this->aRequestErrors`
- Syntax error in switch statement: should use colon, not semicolon

## Proposed solution (bug and enhancement)
<!--
- Changed all references of `$this->m_aWebrequestErrors` to `$this->aRequestErrors`
- Fixed switch statement to use colon: `case ...:`
- Removed unused imports from test file for code cleanliness
-->

- Corrected property name in `_ActionWebhook.php`
- Fixed switch case syntax
- Removed unused imports in `_ActionWebhookTest.php`

## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] Would a unit test be relevant and have I added it? (N/A, covered by existing tests)
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?

## Checklist of things to do before PR is ready to merge
<!--
Things that needs to be done in the PR before it can be considered as ready to be merged

Examples:
- Changes requested in the review
- Unit test to add
- Dictionary entries to translate
- ...
-->

- [ ] Review requested changes (if any)
- [ ] Confirm all tests pass
- [ ] Update documentation if needed