### PR TITLE
N°9519 - Add proxy to Webhook Request

### DIFF
--- a/module.combodo-webhook-integration.php
+++ b/module.combodo-webhook-integration.php
@@ -5,7 +5,7 @@
 //
 //
 SetupWebPage::AddModule(__FILE__, // Path to the current file, all other file names are relative to the directory containing this file
-	'combodo-webhook-integration/1.4.5',
+	'combodo-webhook-integration/1.4.4',
 	array(
 		//
 		'label' => 'Webhook integrations',
@@ -44,7 +44,14 @@ SetupWebPage::AddModule(__FILE__, // Path to the current file, all other file na
 
 		// Default settings
 		//
-		'settings' => array(),
+		'settings' => array(
+		// Configuración de proxy para las llamadas salientes de los webhooks
+			'proxy' => array(
+				'host'     => 'ip.roxy:3128', // IP:PUERTO de tu proxy
+				'user'     => '',                 // si no requiere auth, dejalo vacío
+				'password' => '',
+			)
+		)
 	)
 );
 

--- a/src/Service/WebRequestSender.php
+++ b/src/Service/WebRequestSender.php
@@ -124,6 +124,37 @@ class WebRequestSender
 	{
 		try
 		{
+			// ============================
+			//  Inyectar opciones de proxy
+			// ============================
+			$oConfig    = MetaModel::GetConfig();
+			$aProxyConf = $oConfig->GetModuleSetting('combodo-webhook-integration', 'proxy', null);
+
+			if (is_array($aProxyConf) && !empty($aProxyConf['host'])) {
+				// Recuperar opciones actuales del request (si no hay, iniciamos array vacío)
+				$aCurlOptions = $oRequest->GetOptions();
+				if (!is_array($aCurlOptions)) {
+					$aCurlOptions = array();
+				}
+
+				// Host:puerto del proxy
+				$aCurlOptions[CURLOPT_PROXY]     = $aProxyConf['host'];
+				$aCurlOptions[CURLOPT_PROXYTYPE] = CURLPROXY_HTTP;
+
+				// Auth opcional si el proxy la requiere
+				if (!empty($aProxyConf['user'])) {
+					$sAuth = $aProxyConf['user'];
+					if (!empty($aProxyConf['password'])) {
+						$sAuth .= ':'.$aProxyConf['password'];
+					}
+					$aCurlOptions[CURLOPT_PROXYUSERPWD] = $sAuth;
+				}
+
+				// Guardar las opciones de vuelta en el request
+				$oRequest->SetOptions($aCurlOptions);
+			}
+			// ============================
+
 			$aResponseHeaders = array();
 			$sResponse = $this->DoPostRequest($oRequest->GetURL(), array(), null, $aResponseHeaders, $oRequest->GetOptions());
 
@@ -163,6 +194,7 @@ class WebRequestSender
 			);
 		}
 	}
+
 
 	/**
 	 * Add the $oRequest to the queue in order to be send later


### PR DESCRIPTION
<html><body>


| Question | Answer |
|----------|--------|
| Related to a SourceForge thread / Another PR / Combodo ticket? | https://sourceforge.net/p/itop/discussion/922361/thread/0b15547ab3/ |
| Type of change? | Enhancement |


</div></div><hr data-start="507" data-end="510">
<h2 data-start="512" data-end="554">Symptom (bug) / Objective (enhancement)</h2>
<p data-start="556" data-end="717">In many enterprise environments, iTop servers do not have direct access to the Internet and must route all outbound HTTP/HTTPS traffic through a corporate proxy.</p>
<p data-start="719" data-end="1020">Currently, the webhook integration module does not provide any way to configure a proxy for outbound requests.<br data-start="829" data-end="832">
As a result, webhook calls fail in restricted networks, usually with DNS resolution or connection errors, making integrations with external services (Telegram, Slack, APIs, etc.) unusable.</p>
<p data-start="1022" data-end="1213">The objective of this enhancement is to allow webhook HTTP requests to be routed through a configurable proxy, making the webhook integration usable in secured and restricted infrastructures.</p>
<hr data-start="1215" data-end="1218">
<h2 data-start="1220" data-end="1251">Reproduction procedure (bug)</h2>
<p data-start="1253" data-end="1310"><em data-start="1253" data-end="1310">(Not applicable, this is an enhancement and not a bug.)</em></p>
<hr data-start="1312" data-end="1315">
<h2 data-start="1317" data-end="1331">Cause (bug)</h2>
<p data-start="1333" data-end="1390"><em data-start="1333" data-end="1390">(Not applicable, this is an enhancement and not a bug.)</em></p>
<hr data-start="1392" data-end="1395">
<h2 data-start="1397" data-end="1439">Proposed solution (bug and enhancement)</h2>
<p data-start="1441" data-end="1517">The solution adds optional HTTP proxy support to the webhook request sender:</p>
<ul data-start="1519" data-end="1941">
<li data-start="1519" data-end="1649">
<p data-start="1521" data-end="1578">The proxy configuration is read from the module settings:</p>
<ul data-start="1581" data-end="1649">
<li data-start="1581" data-end="1601">
<p data-start="1583" data-end="1601"><code data-start="1583" data-end="1589">host</code> (mandatory)</p>
</li>
<li data-start="1604" data-end="1623">
<p data-start="1606" data-end="1623"><code data-start="1606" data-end="1612">user</code> (optional)</p>
</li>
<li data-start="1626" data-end="1649">
<p data-start="1628" data-end="1649"><code data-start="1628" data-end="1638">password</code> (optional)</p>
</li>
</ul>
</li>
<li data-start="1650" data-end="1843">
<p data-start="1652" data-end="1738">When a proxy is defined, the corresponding CURL options are injected into the request:</p>
<ul data-start="1741" data-end="1843">
<li data-start="1741" data-end="1758">
<p data-start="1743" data-end="1758"><code data-start="1743" data-end="1758">CURLOPT_PROXY</code></p>
</li>
<li data-start="1761" data-end="1782">
<p data-start="1763" data-end="1782"><code data-start="1763" data-end="1782">CURLOPT_PROXYTYPE</code></p>
</li>
<li data-start="1785" data-end="1843">
<p data-start="1787" data-end="1843"><code data-start="1787" data-end="1809">CURLOPT_PROXYUSERPWD</code> (if authentication is configured)</p>
</li>
</ul>
</li>
<li data-start="1844" data-end="1941">
<p data-start="1846" data-end="1941">When no proxy is defined, the behavior remains unchanged, ensuring full backward compatibility.</p>
</li>
</ul>
<p data-start="1943" data-end="2070">This allows webhook integrations to work transparently in environments where Internet access is only available through a proxy.</p>
<p data-start="2072" data-end="2171">The change is limited to the webhook integration module and does not impact any other part of iTop.</p><!--EndFragment-->
</body>
</html>