### PR TITLE
N°9772 - Migrating token's data in webhooks to avoid setup errors

### DIFF
--- a/module.combodo-webhook-integration.php
+++ b/module.combodo-webhook-integration.php
@@ -1,41 +1,43 @@
 <?php
+
 //
 // iTop module definition file
 //
 //
 //
-SetupWebPage::AddModule(__FILE__, // Path to the current file, all other file names are relative to the directory containing this file
+SetupWebPage::AddModule(
+	__FILE__, // Path to the current file, all other file names are relative to the directory containing this file
 	'combodo-webhook-integration/1.4.6',
-	array(
+	[
 		//
 		'label' => 'Webhook integrations',
 		'category' => 'business',
 
 		// Setup
 		//
-		'dependencies' => array(
+		'dependencies' => [
 			'itop-structure/3.2.0',
 			'itop-attribute-encrypted-password/1.0.0',
 			'combodo-oauth2-client/1.0.0',
-		),
+		],
 		'mandatory' => false,
 		'visible' => true,
 		'installer' => 'WebhookIntegrationInstaller',
 
 		// Components
 		//
-		'datamodel' => array(
+		'datamodel' => [
 			// Extension autoloader
 			'vendor/autoload.php',
 			// Explicitly load DM classes
 			'SendWebRequest.php',
 			'model.combodo-webhook-integration.php',
-		),
-		'webservice' => array(),
-		'data.struct' => array(
+		],
+		'webservice' => [],
+		'data.struct' => [
 			'data.struct.remote_application_type.xml',
-		),
-		'data.sample' => array(),
+		],
+		'data.sample' => [],
 
 		// Documentation
 		//
@@ -44,12 +46,11 @@ SetupWebPage::AddModule(__FILE__, // Path to the current file, all other file na
 
 		// Default settings
 		//
-		'settings' => array(),
-	)
+		'settings' => [],
+	]
 );
 
-if (!class_exists('WebhookIntegrationInstaller'))
-{
+if (!class_exists('WebhookIntegrationInstaller')) {
 	// Module installation handler
 	//
 	class WebhookIntegrationInstaller extends ModuleInstallerAPI
@@ -73,16 +74,16 @@ if (!class_exists('WebhookIntegrationInstaller'))
 				SetupLog::Info("|  ActionWebhook migration done.");
 			}
 
-            // In combodo-webhook-integration v1.4.2, bug N°7875 led to token format change
-            if (version_compare($sPreviousVersion, '1.4.2', '<')) {
-                SetupLog::Info("|  Migrate RemoteiTopConnectionToken token format.");
-                self::MigrateTokenFromEncryptedBlobToString();
-                SetupLog::Info("|  RemoteiTopConnectionToken migration done.");
-            }
+			// In combodo-webhook-integration v1.4.2, bug N°7875 led to token format change
+			if (version_compare($sPreviousVersion, '1.4.2', '<')) {
+				SetupLog::Info("|  Migrate RemoteiTopConnectionToken token format.");
+				self::MigrateTokenFromEncryptedBlobToString();
+				SetupLog::Info("|  RemoteiTopConnectionToken migration done.");
+			}
 		}
 
 		/**
-         * Convert token encrypted binary format into clear token strings to prevent new column format from rejecting the data.
+		 * Convert token encrypted binary format into clear token strings to prevent new column format from rejecting the data.
 		 *
 		 * @throws Exception When at least one token cannot be migrated safely.
 		 */
@@ -92,10 +93,10 @@ if (!class_exists('WebhookIntegrationInstaller'))
 				return;
 			}
 
-            // Note: There is an issue when upgrading, encryption values cannot be retrieved from the passed configuration, we have to read it from the disk
-            $oDiskConfig = utils::GetConfig(true);
+			// Note: There is an issue when upgrading, encryption values cannot be retrieved from the passed configuration, we have to read it from the disk
+			$oDiskConfig = utils::GetConfig(true);
 
-            $sClass = 'RemoteiTopConnectionToken';
+			$sClass = 'RemoteiTopConnectionToken';
 			$sTable = MetaModel::DBGetTable($sClass);
 			$sColumn = MetaModel::GetAttributeDef($sClass, 'token')->Get('sql');
 
@@ -105,7 +106,7 @@ if (!class_exists('WebhookIntegrationInstaller'))
 			}
 
 			$sFieldType = strtolower((string) CMDBSource::GetFieldType($sTable, $sColumn));
-            // Check if we're dealing with a *blob (tinyblob is expected from the AttributeEncryptedString definition)
+			// Check if we're dealing with a *blob (tinyblob is expected from the AttributeEncryptedString definition)
 			if (strpos($sFieldType, 'blob') === false) {
 				SetupLog::Info("|  Token migration skipped: column already non-binary ({$sFieldType}).");
 				return;
@@ -118,19 +119,20 @@ if (!class_exists('WebhookIntegrationInstaller'))
 				return;
 			}
 
-            // Load SimpleCrypt object to decrypt values
+			// Load SimpleCrypt object to decrypt values
 			$oSimpleCrypt = new SimpleCrypt($oDiskConfig->GetEncryptionLibrary());
 			$sEncryptionKey = $oDiskConfig->GetEncryptionKey();
 
 			$sDecryptError = Dict::S('Core:AttributeEncryptFailedToDecrypt');
 			$iMigrated = 0;
+			$aUpdatedValues = [];
 			$aFailedIds = [];
 
 			foreach ($aRows as $aRow) {
 				$iId = (int) $aRow['id'];
 				$sEncryptedValue = $aRow['token'];
 
-                // Try to decrypt token raw value
+				// Try to decrypt token raw value
 				try {
 					$sDecryptedValue = $oSimpleCrypt->Decrypt($sEncryptionKey, $sEncryptedValue);
 				} catch (Exception $e) {
@@ -139,21 +141,33 @@ if (!class_exists('WebhookIntegrationInstaller'))
 					continue;
 				}
 
-                // If the decrypted value equals common error message, consider something went wrong and skip this line
+				// If the decrypted value equals common error message, consider something went wrong and skip this line
 				if ($sDecryptedValue === $sDecryptError) {
 					$aFailedIds[] = $iId;
 					SetupLog::Error("|  Token migration failed for id={$iId}: decryption error.");
 					continue;
 				}
 
-				$sUpdateQuery = "UPDATE `{$sTable}` SET `{$sColumn}` = ".CMDBSource::Quote($sDecryptedValue)." WHERE `id` = {$iId}";
-				CMDBSource::Query($sUpdateQuery);
-				$iMigrated++;
+				$aUpdatedValues[$iId] = $sDecryptedValue;
 			}
 
-            // Throw an exception before trying to go forward with the database if we couldn't decipher all values, avoiding MySQL errors
+			// Throw an exception before trying to go forward with the database if we couldn't decipher all values, avoiding MySQL errors
 			if (!empty($aFailedIds)) {
 				throw new Exception('|  Token migration aborted: unable to decrypt token values for ids '.implode(', ', $aFailedIds).'.');
+			}
+
+			CMDBSource::Query('START TRANSACTION');
+			try {
+				foreach ($aUpdatedValues as $iId => $sDecryptedValue) {
+					CMDBSource::Query(
+						"UPDATE `{$sTable}` SET `{$sColumn}` = ".CMDBSource::Quote($sDecryptedValue)." WHERE `id` = {$iId}"
+					);
+					$iMigrated++;
+				}
+				CMDBSource::Query('COMMIT');
+			} catch (Exception $e) {
+				CMDBSource::Query('ROLLBACK');
+				throw new Exception('|  Token migration aborted: unable to insert updated data into database column: '.$e->getMessage().'.');
 			}
 
 			SetupLog::Info("|  Token migration done: {$iMigrated} row(s) decrypted to clear string.");

--- a/module.combodo-webhook-integration.php
+++ b/module.combodo-webhook-integration.php
@@ -130,7 +130,7 @@ if (!class_exists('WebhookIntegrationInstaller')) {
 
 			foreach ($aRows as $aRow) {
 				$iId = (int) $aRow['id'];
-				$sEncryptedValue = $aRow['token'];
+				$sEncryptedValue = $aRow[$sColumn];
 
 				// Try to decrypt token raw value
 				try {

--- a/module.combodo-webhook-integration.php
+++ b/module.combodo-webhook-integration.php
@@ -72,6 +72,91 @@ if (!class_exists('WebhookIntegrationInstaller'))
 				self::MoveColumnInDB($sTableToRead, 'language', $sTableToSet, 'language', true);
 				SetupLog::Info("|  ActionWebhook migration done.");
 			}
+
+            // In combodo-webhook-integration v1.4.2, bug N°7875 led to token format change
+            if (version_compare($sPreviousVersion, '1.4.2', '<')) {
+                SetupLog::Info("|  Migrate RemoteiTopConnectionToken token format.");
+                self::MigrateTokenFromEncryptedBlobToString();
+                SetupLog::Info("|  RemoteiTopConnectionToken migration done.");
+            }
+		}
+
+		/**
+         * Convert token encrypted binary format into clear token strings to prevent new column format from rejecting the data.
+		 *
+		 * @throws Exception When at least one token cannot be migrated safely.
+		 */
+		private static function MigrateTokenFromEncryptedBlobToString()
+		{
+			if (!MetaModel::DBExists(false)) {
+				return;
+			}
+
+            // Note: There is an issue when upgrading, encryption values cannot be retrieved from the passed configuration, we have to read it from the disk
+            $oDiskConfig = utils::GetConfig(true);
+
+            $sClass = 'RemoteiTopConnectionToken';
+			$sTable = MetaModel::DBGetTable($sClass);
+			$sColumn = MetaModel::GetAttributeDef($sClass, 'token')->Get('sql');
+
+			if (!CMDBSource::IsTable($sTable) || !CMDBSource::IsField($sTable, $sColumn)) {
+				SetupLog::Info("|  Token migration skipped: table/column not found.");
+				return;
+			}
+
+			$sFieldType = strtolower((string) CMDBSource::GetFieldType($sTable, $sColumn));
+            // Check if we're dealing with a *blob (tinyblob is expected from the AttibuteEncryptedString definition)
+			if (strpos($sFieldType, 'blob') === false) {
+				SetupLog::Info("|  Token migration skipped: column already non-binary ({$sFieldType}).");
+				return;
+			}
+
+			SetupLog::Info("|  Migrating encrypted token payloads from binary column {$sTable}.{$sColumn}.");
+			$aRows = CMDBSource::QueryToArray("SELECT `id`, `{$sColumn}` FROM `{$sTable}` WHERE `{$sColumn}` IS NOT NULL AND LENGTH(`{$sColumn}`) > 0");
+			if (empty($aRows)) {
+				SetupLog::Info("|  Token migration skipped: no non-empty values found.");
+				return;
+			}
+
+            // Load SimpleCrypt object to decrypt values
+			$oSimpleCrypt = new SimpleCrypt($oDiskConfig->GetEncryptionLibrary());
+			$sEncryptionKey = $oDiskConfig->GetEncryptionKey();
+
+			$sDecryptError = Dict::S('Core:AttributeEncryptFailedToDecrypt');
+			$iMigrated = 0;
+			$aFailedIds = [];
+
+			foreach ($aRows as $aRow) {
+				$iId = (int) $aRow['id'];
+				$sEncryptedValue = $aRow['token'];
+
+                // Try to decrypt token raw value
+				try {
+					$sDecryptedValue = $oSimpleCrypt->Decrypt($sEncryptionKey, $sEncryptedValue);
+				} catch (Exception $e) {
+					$aFailedIds[] = $iId;
+					SetupLog::Error("|  Token migration failed for id={$iId}: {$e->getMessage()}");
+					continue;
+				}
+
+                // If the decrypted value equals common error message, consider something went wrong and skip this line
+				if ($sDecryptedValue === $sDecryptError) {
+					$aFailedIds[] = $iId;
+					SetupLog::Error("|  Token migration failed for id={$iId}: decryption error.");
+					continue;
+				}
+
+				$sUpdateQuery = "UPDATE `{$sTable}` SET `{$sColumn}` = ".CMDBSource::Quote($sDecryptedValue)." WHERE `id` = {$iId}";
+				CMDBSource::Query($sUpdateQuery);
+				$iMigrated++;
+			}
+
+            // Throw an exception before trying to go forward with the database if we couldn't decipher all values, avoiding MySQL errors
+			if (!empty($aFailedIds)) {
+				throw new Exception('|  Token migration aborted: unable to decrypt token values for ids '.implode(', ', $aFailedIds).'.');
+			}
+
+			SetupLog::Info("|  Token migration done: {$iMigrated} row(s) decrypted to clear string.");
 		}
 	}
 }

--- a/module.combodo-webhook-integration.php
+++ b/module.combodo-webhook-integration.php
@@ -105,7 +105,7 @@ if (!class_exists('WebhookIntegrationInstaller'))
 			}
 
 			$sFieldType = strtolower((string) CMDBSource::GetFieldType($sTable, $sColumn));
-            // Check if we're dealing with a *blob (tinyblob is expected from the AttibuteEncryptedString definition)
+            // Check if we're dealing with a *blob (tinyblob is expected from the AttributeEncryptedString definition)
 			if (strpos($sFieldType, 'blob') === false) {
 				SetupLog::Info("|  Token migration skipped: column already non-binary ({$sFieldType}).");
 				return;


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N°9772
| Type of change?                                               | Bug fix

## Symptom (bug) 
When updating to a recent iTop version with existing `RemoteiTopConnectionToken`, setup crashes as follow:

```
query = ALTER TABLE `remoteitopconnectiontoken` CHANGE `token` `token` VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT '', mysql_errno = 1366, mysql_error = Incorrect string value: '\xECn\xF3\xBC\x0F\xC4...' for column `sumitsud`.`remoteitopconnectiontoken`.`token` at row 1
```


## Reproduction procedure (bug)

1. On iTop 3.1.3 with combodo-webhook-integration < 1.4.2
2. Create a webhook notification with one or multiple `RemoteiTopConnectionToken`
3. Upgrade iTop to 3.2.2 with combodo-webhook-integration >= 1.4.2
4. Finally, see that the setup doesn't pass


## Cause (bug)
In v1.4.2 due to bug N°7875 unexpected revert, the token attribute went from AttributeEncryptedString to AttributeEncryptedPassword to AttributeString in a matter of a single version. 

Data went from encrypted `tinyblob` to clear `VARCHAR(255)`, bringing potential invalid characters to a varchar column


## Proposed solution 
This pull request add a migration step as a BeforeDatabaseCreation method that tries to decrypt `token` data if it's part of a `*blob` column, and the update the token column data with the clear value.
This lead column type migration that happens later to work 


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] Would a unit test be relevant and have I added it?
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?

## Workaround

A workaround to this issue:
1. While still with combodo-webhook-integration < 1.4.2, export your `RemoteiTopConnectionToken` with a CSV export
2. Clear your database token column
3. Upgrade you combodo-webhook-integration while token column is empty
4. Import back your `RemoteiTopConnectionToken` so the token column is populated with the clear data

<img width="1915" height="1040" alt="Screenshot From 2026-07-13 09-51-07" src="https://github.com/user-attachments/assets/38693721-fabd-4b90-98e8-e477d0e8732d" />

<img width="1915" height="1040" alt="Screenshot From 2026-07-13 09-50-46" src="https://github.com/user-attachments/assets/2d7ece90-f67a-41b3-a1fa-c61006cf7081" />

<img width="1915" height="1040" alt="Screenshot From 2026-07-13 09-51-17" src="https://github.com/user-attachments/assets/b866a458-a261-4ded-8a76-262eca2df04a" />

<img width="1915" height="1040" alt="Screenshot From 2026-07-13 09-51-24" src="https://github.com/user-attachments/assets/09d35e79-b904-410d-80d4-8a5f605ef02a" />


<img width="1915" height="1040" alt="Screenshot From 2026-07-13 09-54-19" src="https://github.com/user-attachments/assets/bc3e3eb5-2423-487e-8a57-1e3e60937913" />

<img width="1915" height="1040" alt="Screenshot From 2026-07-13 09-54-46" src="https://github.com/user-attachments/assets/0d614848-cf95-4992-adfa-2ae2a03a9b2b" />

<img width="1915" height="1040" alt="Screenshot From 2026-07-13 09-54-54" src="https://github.com/user-attachments/assets/9b9c95ed-8a89-4cdf-9429-1f452c2eb841" />